### PR TITLE
chat: fix event decode

### DIFF
--- a/cbor/event.go
+++ b/cbor/event.go
@@ -112,7 +112,7 @@ func EventFromRecord(ctx context.Context, dag format.DAGService, rec thread.Reco
 
 	event, ok := block.(*Event)
 	if !ok {
-		return nil, fmt.Errorf("invalid event")
+		return EventFromNode(block)
 	}
 	return event, nil
 }

--- a/examples/chat/main.go
+++ b/examples/chat/main.go
@@ -48,7 +48,7 @@ var (
 
 	cursor = green(">  ")
 
-	log = logging.Logger("shell")
+	log = logging.Logger("chat")
 )
 
 const (
@@ -98,16 +98,16 @@ func main() {
 
 	util.SetupDefaultLoggingConfig(*repo)
 	if *debug {
-		if err := logging.SetLogLevel("shell", "debug"); err != nil {
+		if err := logging.SetLogLevel("chat", "debug"); err != nil {
 			log.Fatal(err)
 		}
 	}
 
-	shellPath := filepath.Join(*repo, "shell")
-	if err = os.MkdirAll(shellPath, os.ModePerm); err != nil {
+	chatPath := filepath.Join(*repo, "chat")
+	if err = os.MkdirAll(chatPath, os.ModePerm); err != nil {
 		log.Fatal(err)
 	}
-	ds, err = ipfslite.BadgerDatastore(shellPath)
+	ds, err = ipfslite.BadgerDatastore(chatPath)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -155,17 +155,17 @@ func main() {
 				logError(err)
 				continue
 			}
-			event, err := cbor.EventFromRecord(ctx, ts, rec.Value())
-			if err != nil {
-				logError(err)
-				continue
-			}
 			key, err := ts.Store().ReadKey(rec.ThreadID())
 			if err != nil {
 				logError(err)
 				continue
 			}
 			if key == nil {
+				continue // just following, we don't have the read key
+			}
+			event, err := cbor.EventFromRecord(ctx, ts, rec.Value())
+			if err != nil {
+				logError(err)
 				continue
 			}
 			node, err := event.GetBody(ctx, ts, key)
@@ -199,7 +199,7 @@ func main() {
 		}
 	}()
 
-	log.Debug("shell started")
+	log.Debug("chat started")
 
 	reader := bufio.NewReader(os.Stdin)
 	for {


### PR DESCRIPTION
Closes #170 

Two fixes:
1. The global chat subscription reports records from all threads, including ones we are just following. So, we can safely skip records from threads where the read key is missing.
2. Fallback to `EventFromNode` when the type assertion in `EventFromRecord` fails.