### PR TITLE
ds: moves logstore out of ipfs datastore

### DIFF
--- a/store/util.go
+++ b/store/util.go
@@ -102,7 +102,6 @@ func DefaultService(repoPath string, opts ...ServiceOption) (ServiceBoostrapper,
 		return nil, err
 	}
 	logstore, err := badger.NewDatastore(logstorePath, &badger.DefaultOptions)
-
 	if err != nil {
 		cancel()
 		litestore.Close()

--- a/store/util.go
+++ b/store/util.go
@@ -111,6 +111,7 @@ func DefaultService(repoPath string, opts ...ServiceOption) (ServiceBoostrapper,
 	tstore, err := lstoreds.NewLogstore(ctx, logstore, lstoreds.DefaultOpts())
 	if err != nil {
 		cancel()
+		logstore.Close()
 		litestore.Close()
 		return nil, err
 	}


### PR DESCRIPTION
to help investigate storage issues (https://github.com/textileio/go-threads/issues/203), this splits the logstore out of the litestore 