### PR TITLE
[wip] Don't GetRecord on initial Record

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -590,9 +590,14 @@ func (t *service) putRecord(ctx context.Context, id thread.ID, lid peer.ID, rec 
 		if exist {
 			break
 		}
-		r, err := t.GetRecord(ctx, id, c)
-		if err != nil {
-			return err
+		var r core.Record
+		if c.String() != rec.Cid().String() {
+			r, err = t.GetRecord(ctx, id, c)
+			if err != nil {
+				return err
+			}
+		} else {
+			r = rec
 		}
 		unknownRecords = append(unknownRecords, r)
 		c = r.PrevID()


### PR DESCRIPTION
This is a simple check that doesn't `GetRecord` if the given CID is from the initial Record. This makes it possible for remote peers to post 'cached' Blocks within the incoming Record, avoiding having to get the Block from the DAG Service. This is particularly useful for things like chat, and other small messages. It also means, peers without access to IPFS can essentially send along full Blocks. This is also needed as part of our ongoing remote JS-Threads implementation.