### PR TITLE
Service fixes

### DIFF
--- a/logstore/lstoreds/addr_book_gc.go
+++ b/logstore/lstoreds/addr_book_gc.go
@@ -82,12 +82,12 @@ func (gc *dsAddrBookGc) purgeStore() {
 
 	batch, err := newCyclicBatch(gc.ab.ds, defaultOpsPerCyclicBatch)
 	if err != nil {
-		log.Warningf("failed while creating batch to purge GC entries: %v", err)
+		log.Warnf("failed while creating batch to purge GC entries: %v", err)
 	}
 
 	results, err := gc.ab.ds.Query(purgeStoreQuery)
 	if err != nil {
-		log.Warningf("failed while opening iterator: %v", err)
+		log.Warnf("failed while opening iterator: %v", err)
 		return
 	}
 	defer results.Close()
@@ -97,7 +97,7 @@ func (gc *dsAddrBookGc) purgeStore() {
 	for result := range results.Next() {
 		record.Reset()
 		if err = record.Unmarshal(result.Value); err != nil {
-			log.Warningf("key %v has an unmarshable record", result.Key)
+			log.Warnf("key %v has an unmarshable record", result.Key)
 			continue
 		}
 
@@ -107,12 +107,12 @@ func (gc *dsAddrBookGc) purgeStore() {
 
 		id := genCacheKey(record.ThreadID.ID, record.PeerID.ID)
 		if err := record.flush(batch); err != nil {
-			log.Warningf("failed to flush entry modified by GC for peer: &v, err: %v", id, err)
+			log.Warnf("failed to flush entry modified by GC for peer: &v, err: %v", id, err)
 		}
 		gc.ab.cache.Remove(id)
 	}
 
 	if err = batch.Commit(); err != nil {
-		log.Warningf("failed to commit GC purge batch: %v", err)
+		log.Warnf("failed to commit GC purge batch: %v", err)
 	}
 }

--- a/logstore/lstoreds/headbook.go
+++ b/logstore/lstoreds/headbook.go
@@ -60,7 +60,7 @@ func (hb *dsHeadBook) AddHeads(t thread.ID, p peer.ID, heads []cid.Cid) error {
 	}
 	for i := range heads {
 		if !heads[i].Defined() {
-			log.Warningf("ignoring head %s is is undefined for %s", heads[i], key)
+			log.Warnf("ignoring head %s is is undefined for %s", heads[i], key)
 			continue
 		}
 		if _, ok := set[heads[i]]; !ok {
@@ -87,7 +87,7 @@ func (hb *dsHeadBook) SetHeads(t thread.ID, p peer.ID, heads []cid.Cid) error {
 	hr := pb.HeadBookRecord{}
 	for i := range heads {
 		if !heads[i].Defined() {
-			log.Warningf("ignoring head %s is undefined for %s", heads[i], key)
+			log.Warnf("ignoring head %s is undefined for %s", heads[i], key)
 			continue
 		}
 		entry := &pb.HeadBookRecord_HeadEntry{Cid: &pb.ProtoCid{Cid: heads[i]}}

--- a/logstore/lstoremem/addr_book.go
+++ b/logstore/lstoremem/addr_book.go
@@ -184,7 +184,7 @@ func (mab *memoryAddrBook) AddAddrs(t thread.ID, p peer.ID, addrs []ma.Multiaddr
 	exp := time.Now().Add(ttl)
 	for _, a := range addrs {
 		if a == nil {
-			log.Warningf("was passed nil multiaddr for %s", p)
+			log.Warnf("was passed nil multiaddr for %s", p)
 			continue
 		}
 		asBytes := a.Bytes()
@@ -231,7 +231,7 @@ func (mab *memoryAddrBook) SetAddrs(t thread.ID, p peer.ID, addrs []ma.Multiaddr
 	exp := time.Now().Add(ttl)
 	for _, a := range addrs {
 		if a == nil {
-			log.Warningf("was passed nil multiaddr for %s", p)
+			log.Warnf("was passed nil multiaddr for %s", p)
 			continue
 		}
 

--- a/logstore/lstoremem/headbook.go
+++ b/logstore/lstoremem/headbook.go
@@ -51,7 +51,7 @@ func (mhb *memoryHeadBook) AddHeads(t thread.ID, p peer.ID, heads []cid.Cid) err
 
 	for _, h := range heads {
 		if !h.Defined() {
-			log.Warningf("was passed nil head for %s", p)
+			log.Warnf("was passed nil head for %s", p)
 			continue
 		}
 		hmap[h] = struct{}{}
@@ -78,7 +78,7 @@ func (mhb *memoryHeadBook) SetHeads(t thread.ID, p peer.ID, heads []cid.Cid) err
 
 	for _, h := range heads {
 		if !h.Defined() {
-			log.Warningf("was passed nil head for %s", p)
+			log.Warnf("was passed nil head for %s", p)
 			continue
 		}
 		hmap[h] = struct{}{}

--- a/service/client.go
+++ b/service/client.go
@@ -56,7 +56,7 @@ func (s *server) getLogs(ctx context.Context, id thread.ID, pid peer.ID) ([]thre
 	client := pb.NewServiceClient(conn)
 	reply, err := client.GetLogs(cctx, req)
 	if err != nil {
-		log.Warningf("get logs from %s failed: %s", pid.String(), err)
+		log.Warnf("get logs from %s failed: %s", pid.String(), err)
 		return nil, err
 	}
 
@@ -102,7 +102,7 @@ func (s *server) pushLog(ctx context.Context, id thread.ID, lid peer.ID, pid pee
 	client := pb.NewServiceClient(conn)
 	_, err = client.PushLog(cctx, lreq)
 	if err != nil {
-		log.Warningf("push log to %s failed: %s", pid.String(), err)
+		log.Warnf("push log to %s failed: %s", pid.String(), err)
 	}
 	return err
 }
@@ -225,7 +225,7 @@ func (s *server) getRecords(
 			client := pb.NewServiceClient(conn)
 			reply, err := client.GetRecords(cctx, req)
 			if err != nil {
-				log.Warningf("get records from %s failed: %s", p, err)
+				log.Warnf("get records from %s failed: %s", p, err)
 				return
 			}
 			for _, l := range reply.Logs {
@@ -358,12 +358,12 @@ func (s *server) pushRecord(ctx context.Context, id thread.ID, lid peer.ID, rec 
 						Log:      logToProto(l),
 					}
 					if _, err = client.PushLog(cctx, lreq); err != nil {
-						log.Warningf("push log to %s failed: %s", p, err)
+						log.Warnf("push log to %s failed: %s", p, err)
 						return
 					}
 					return
 				}
-				log.Warningf("push record to %s failed: %s", p, err)
+				log.Warnf("push record to %s failed: %s", p, err)
 				return
 			}
 		}(addr)

--- a/service/server.go
+++ b/service/server.go
@@ -284,7 +284,7 @@ func (s *server) subscribe(id thread.ID) {
 
 		_, err = s.PushRecord(s.threads.ctx, req)
 		if err != nil {
-			log.Warningf("pubsub: %s", err)
+			log.Warnf("pubsub: %s", err)
 			continue
 		}
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -564,7 +564,7 @@ func (t *service) Subscribe(opts ...core.SubOption) core.Subscription {
 					listener.ch <- r
 				}
 			} else {
-				log.Warning("listener received a non-record value")
+				log.Warn("listener received a non-record value")
 			}
 		}
 		close(listener.ch)
@@ -758,7 +758,7 @@ func (t *service) getLocalRecords(
 	}
 
 	if len(lg.Heads) == 0 {
-		log.Warning("pull found empty log")
+		log.Warn("pull found empty log")
 		return []core.Record{}, nil
 	}
 

--- a/store/listeners.go
+++ b/store/listeners.go
@@ -96,7 +96,7 @@ func (scn *stateChangedNotifee) notify(actions []Action) {
 				select {
 				case l.c <- a:
 				default:
-					log.Warningf("dropped action %v for reducer with filters %v", a, l.filters)
+					log.Warnf("dropped action %v for reducer with filters %v", a, l.filters)
 				}
 			}
 		}

--- a/store/storethread.go
+++ b/store/storethread.go
@@ -166,7 +166,7 @@ func (a *singleThreadAdapter) getBlockWithRetry(ctx context.Context, rec service
 		if err == nil {
 			return n, nil
 		}
-		log.Warningf("error when fetching block %s in retry %d", rec.Cid(), i)
+		log.Warnf("error when fetching block %s in retry %d", rec.Cid(), i)
 		time.Sleep(backoffTime)
 		backoffTime *= 2
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -165,8 +165,8 @@ func DecodeKey(k string) (*sym.Key, error) {
 
 // SetupDefaultLoggingConfig sets up a standard logging configuration.
 func SetupDefaultLoggingConfig(repoPath string) {
-	os.Setenv("GOLOG_LOG_FMT", "color")
-	os.Setenv("GOLOG_FILE", filepath.Join(repoPath, "log", "threads.log"))
+	_ = os.Setenv("GOLOG_LOG_FMT", "color")
+	_ = os.Setenv("GOLOG_FILE", filepath.Join(repoPath, "log", "threads.log"))
 	logging.SetupLogging()
 	logging.SetAllLoggers(logging.LevelError)
 }


### PR DESCRIPTION
- Fixing IDE warnings as `log.Warningf` is now deprecated.
- `AddFollower` should update local addresses _before_ sending logs to the follower.
- `putRecord` should not attempt to "inflate" the given (first) record, as its contents won't be reachable by the `DAGService` yet (block, header, body, are already inflated). However, inflation is required during traversal. 