### PR TITLE
Proposed changes to simplify Event Codec interface

### DIFF
--- a/core/store/store.go
+++ b/core/store/store.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"github.com/google/uuid"
-	ds "github.com/ipfs/go-datastore"
 	format "github.com/ipfs/go-ipld-format"
 )
 
@@ -34,6 +33,7 @@ type Event interface {
 	Time() []byte
 	EntityID() EntityID
 	Model() string
+	Type() ActionType
 }
 
 // ActionType is the type used by actions done in a txn
@@ -71,11 +71,16 @@ type ReduceAction struct {
 	EntityID EntityID
 }
 
+type CodecResult struct {
+	Action ReduceAction
+	State  []byte
+}
+
 // EventCodec transforms actions generated in models to
 // events dispatched to thread logs, and viceversa.
 type EventCodec interface {
 	// Reduce applies generated events into state
-	Reduce(events []Event, datastore ds.TxnDatastore, baseKey ds.Key) ([]ReduceAction, error)
+	Reduce(events Event, oldState []byte) (*CodecResult, error)
 	// Create corresponding events to be dispatched
 	Create(ops []Action) ([]Event, format.Node, error)
 	// EventsFromBytes deserializes a format.Node bytes payload into

--- a/core/store/store.go
+++ b/core/store/store.go
@@ -33,7 +33,6 @@ type Event interface {
 	Time() []byte
 	EntityID() EntityID
 	Model() string
-	Type() ActionType
 }
 
 // ActionType is the type used by actions done in a txn

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/multiformats/go-multihash v0.0.10
 	github.com/multiformats/go-varint v0.0.2 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
-	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2 // indirect
+	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/polydawn/refmt v0.0.0-20190807091052-3d65705ee9f1 // indirect
 	github.com/rs/cors v1.7.0 // indirect
 	github.com/whyrusleeping/base32 v0.0.0-20170828182744-c30ac30633cc

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,6 @@ github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uG
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/hsanjuan/ipfs-lite v0.1.7 h1:/Z3r8hvIPYe6YYJRR3YY84XNzbKvlxhY3pGe0sMOw6Q=
-github.com/hsanjuan/ipfs-lite v0.1.7/go.mod h1:4qiuVY1Kfdt0IRpG79SRudACfrogZ4bdsTf4txZoz6U=
 github.com/hsanjuan/ipfs-lite v0.1.8 h1:IcDOeDI1kHsr3R3ySRSYoEaF7VsqI9ZgC+6tSW+hs6k=
 github.com/hsanjuan/ipfs-lite v0.1.8/go.mod h1:rDx44tRu1bwKZ/LsBYuPJKxAMUodgrOAkSDceZikCFE=
 github.com/huin/goupnp v1.0.0 h1:wg75sLpL6DZqwHQN6E1Cfk6mtfzS45z8OV+ic+DtHRo=

--- a/jsonpatcher/jsonpatcher.go
+++ b/jsonpatcher/jsonpatcher.go
@@ -16,6 +16,8 @@ import (
 	core "github.com/textileio/go-threads/core/store"
 )
 
+// operationType is the type of the operation.
+// It is intentionally unique from core.ActionType to provide greater flexibility.
 type operationType int
 
 const (

--- a/store/dispatcher_test.go
+++ b/store/dispatcher_test.go
@@ -157,5 +157,9 @@ func (n *nullEvent) Node() (format.Node, error) {
 	return nil, nil
 }
 
+func (n *nullEvent) Type() core.ActionType {
+	return core.Delete
+}
+
 // Sanity check
 var _ core.Event = (*nullEvent)(nil)

--- a/store/dispatcher_test.go
+++ b/store/dispatcher_test.go
@@ -157,9 +157,5 @@ func (n *nullEvent) Node() (format.Node, error) {
 	return nil, nil
 }
 
-func (n *nullEvent) Type() core.ActionType {
-	return core.Delete
-}
-
 // Sanity check
 var _ core.Event = (*nullEvent)(nil)

--- a/store/listeners.go
+++ b/store/listeners.go
@@ -43,15 +43,21 @@ func (s *Store) notifyTxnEvents(node format.Node) error {
 	return s.localEventsBus.send(node)
 }
 
+// ActionType is the type of the action.
+// It is intentionally unique from core.ActionType to provide greater flexibility.
 type ActionType int
+
+// ListenActionType is the type for a listener.
 type ListenActionType int
 
+// The set of ActionTypes
 const (
 	ActionCreate ActionType = iota + 1
 	ActionSave
 	ActionDelete
 )
 
+// The set of ListenActionTypes
 const (
 	ListenAll ListenActionType = iota
 	ListenCreate
@@ -59,18 +65,21 @@ const (
 	ListenDelete
 )
 
+// Action is an operation that can be observed
 type Action struct {
 	Model string
 	Type  ActionType
 	ID    core.EntityID
 }
 
+// ListenOption is a configuration option for observing Actions
 type ListenOption struct {
 	Type  ListenActionType
 	Model string
 	ID    core.EntityID
 }
 
+// Listener is an interface describing an object with an Action channel
 type Listener interface {
 	Channel() <-chan Action
 	Close()

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	ds "github.com/ipfs/go-datastore"
 	format "github.com/ipfs/go-ipld-format"
 	"github.com/multiformats/go-multiaddr"
 	core "github.com/textileio/go-threads/core/store"
@@ -318,7 +317,7 @@ type mockEventCodec struct {
 
 var _ core.EventCodec = (*mockEventCodec)(nil)
 
-func (dec *mockEventCodec) Reduce(events []core.Event, datastore ds.TxnDatastore, baseKey ds.Key) ([]core.ReduceAction, error) {
+func (dec *mockEventCodec) Reduce(event core.Event, oldState []byte) (*core.CodecResult, error) {
 	dec.called = true
 	return nil, nil
 }


### PR DESCRIPTION
Nothing ground-breaking here. Just moved all the datastore-based logic from EventCodec into the Store's Reduce method. It does however, add a new method to the Event interface. Note that the Store is actually the only place this is used, so I think think 'breaking' change is probably ok? In doing this, it simplifies things a bit for the Store's Reducer.

I'll also leave some 'inline' comments for things I'd like some clarification on.