### PR TITLE
thread: Use a dedicated type for thread variants

### DIFF
--- a/core/thread/id_test.go
+++ b/core/thread/id_test.go
@@ -48,7 +48,7 @@ func TestID_Variant(t *testing.T) {
 		t.Errorf("got wrong variant from %s: %d", i.String(), v)
 	}
 
-	t.Logf("Variant: %s", VariantToStr[v])
+	t.Logf("Variant: %s", v)
 
 	i = NewIDV1(AccessControlled, 32)
 
@@ -57,5 +57,5 @@ func TestID_Variant(t *testing.T) {
 		t.Errorf("got wrong variant from %s: %d", i.String(), v)
 	}
 
-	t.Logf("Variant: %s", VariantToStr[v])
+	t.Logf("Variant: %s", v)
 }


### PR DESCRIPTION
Often times when trying to instantiate a new thread ID I accidentally pass thread.V1 instead of thread.Raw as a first parameter, since it accepts any uint64 you can pass anything there, and it won't fail.

This PR introduces a dedicated type for thread variants to avoid this kind of human errors.

It also removes a global mapping of thread variants to their string representation and instead implements `fmt.Stringer`. This also protects mapping from being mutated from outside the package.