### PR TITLE
create option for low mem scenarios avoiding mmap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ api/pb/dart/lib
 .vscode/
 
 **/node_modules
+tags

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/alecthomas/jsonschema v0.0.0-20191017121752-4bb6e3fae4f2
 	github.com/c-bata/go-prompt v0.2.3
 	github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f // indirect
+	github.com/dgraph-io/badger v1.6.0
 	github.com/evanphx/json-patch v4.5.0+incompatible
 	github.com/fatih/color v1.7.0
 	github.com/gogo/googleapis v1.3.1 // indirect

--- a/store/manager.go
+++ b/store/manager.go
@@ -35,7 +35,7 @@ func NewManager(ts service.Service, opts ...Option) (*Manager, error) {
 	}
 
 	if config.Datastore == nil {
-		datastore, err := newDefaultDatastore(config.RepoPath)
+		datastore, err := newDefaultDatastore(config.RepoPath, config.LowMem)
 		if err != nil {
 			return nil, err
 		}

--- a/store/options.go
+++ b/store/options.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/dgraph-io/badger/options"
 	ds "github.com/ipfs/go-datastore"
 	badger "github.com/ipfs/go-ds-badger"
 	core "github.com/textileio/go-threads/core/store"
@@ -24,18 +25,23 @@ type Config struct {
 	EventCodec core.EventCodec
 	JsonMode   bool
 	Debug      bool
+	LowMem     bool
 }
 
 func newDefaultEventCodec(jsonMode bool) core.EventCodec {
 	return jsonpatcher.New(jsonMode)
 }
 
-func newDefaultDatastore(repoPath string) (ds.TxnDatastore, error) {
+func newDefaultDatastore(repoPath string, lowMem bool) (ds.TxnDatastore, error) {
 	path := filepath.Join(repoPath, defaultDatastorePath)
 	if err := os.MkdirAll(path, os.ModePerm); err != nil {
 		return nil, err
 	}
-	return badger.NewDatastore(path, &badger.DefaultOptions)
+	opts := badger.DefaultOptions
+	if lowMem {
+		opts.TableLoadingMode = options.FileIO
+	}
+	return badger.NewDatastore(path, &opts)
 }
 
 func WithJsonMode(enabled bool) Option {

--- a/store/options.go
+++ b/store/options.go
@@ -44,6 +44,12 @@ func newDefaultDatastore(repoPath string, lowMem bool) (ds.TxnDatastore, error) 
 	return badger.NewDatastore(path, &opts)
 }
 
+func WithLowMem(low bool) Option {
+	return func(sc *Config) error {
+		sc.LowMem = low
+	}
+}
+
 func WithJsonMode(enabled bool) Option {
 	return func(sc *Config) error {
 		sc.JsonMode = enabled

--- a/store/options.go
+++ b/store/options.go
@@ -47,6 +47,7 @@ func newDefaultDatastore(repoPath string, lowMem bool) (ds.TxnDatastore, error) 
 func WithLowMem(low bool) Option {
 	return func(sc *Config) error {
 		sc.LowMem = low
+		return nil
 	}
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -85,7 +85,7 @@ func NewStore(ts service.Service, opts ...Option) (*Store, error) {
 // with the same config.
 func newStore(ts service.Service, config *Config) (*Store, error) {
 	if config.Datastore == nil {
-		datastore, err := newDefaultDatastore(config.RepoPath)
+		datastore, err := newDefaultDatastore(config.RepoPath, config.LowMem)
 		if err != nil {
 			return nil, err
 		}

--- a/store/util.go
+++ b/store/util.go
@@ -93,6 +93,7 @@ func DefaultService(repoPath string, opts ...ServiceOption) (ServiceBoostrapper,
 	// Build a logstore
 	logstorePath := filepath.Join(repoPath, defaultLogstorePath)
 	if err := os.MkdirAll(logstorePath, os.ModePerm); err != nil {
+		cancel()
 		return nil, err
 	}
 	logstore, err := badger.NewDatastore(logstorePath, &badger.DefaultOptions)


### PR DESCRIPTION
Fixes #203 

A new option is available `WithLowMem(true)` to use direct FileIO and not the mmap (default).