### PR TITLE
Error out when no local thread info

### DIFF
--- a/net/api/service.go
+++ b/net/api/service.go
@@ -112,6 +112,9 @@ func (s *Service) GetThread(ctx context.Context, req *pb.GetThreadRequest) (*pb.
 	if err != nil {
 		return nil, err
 	}
+	if info.ReadKey == nil && info.FollowKey == nil {
+		return nil, fmt.Errorf("empty thread info")
+	}
 	return threadInfoToProto(info)
 }
 


### PR DESCRIPTION
Minor nit discovered when working with the gRPC APIs. Calling getThread when the given Thread does not exist on the remote peer leads to a nil pointer panic. This checks for and returns an error when the FollowKey is not available.