### PR TITLE
Thread Delete

### DIFF
--- a/cbor/event.go
+++ b/cbor/event.go
@@ -11,7 +11,7 @@ import (
 	mh "github.com/multiformats/go-multihash"
 	"github.com/textileio/go-threads/core/net"
 	"github.com/textileio/go-threads/crypto"
-	"github.com/textileio/go-threads/crypto/symmetric"
+	sym "github.com/textileio/go-threads/crypto/symmetric"
 )
 
 func init() {
@@ -33,7 +33,7 @@ type eventHeader struct {
 
 // CreateEvent create a new event by wrapping the body node.
 func CreateEvent(ctx context.Context, dag format.DAGService, body format.Node, rkey crypto.EncryptionKey) (net.Event, error) {
-	key, err := symmetric.NewRandom()
+	key, err := sym.NewRandom()
 	if err != nil {
 		return nil, err
 	}
@@ -116,6 +116,11 @@ func EventFromRecord(ctx context.Context, dag format.DAGService, rec net.Record)
 		return EventFromNode(block)
 	}
 	return event, nil
+}
+
+// RemoveEvent removes an event from the dag service.
+func RemoveEvent(ctx context.Context, dag format.DAGService, e *Event) error {
+	return dag.RemoveMany(ctx, []cid.Cid{e.Cid(), e.HeaderID(), e.BodyID()})
 }
 
 // Event is a IPLD node representing an event.

--- a/cbor/record.go
+++ b/cbor/record.go
@@ -87,6 +87,11 @@ func RecordFromNode(coded format.Node, key crypto.DecryptionKey) (net.Record, er
 	}, nil
 }
 
+// RemoveRecord removes a record from the dag service.
+func RemoveRecord(ctx context.Context, dag format.DAGService, rec net.Record) error {
+	return dag.Remove(ctx, rec.Cid())
+}
+
 // RecordToProto returns a proto version of a record for transport.
 // Nodes are sent encrypted.
 func RecordToProto(ctx context.Context, dag format.DAGService, rec net.Record) (*pb.Log_Record, error) {

--- a/core/logstore/logstore.go
+++ b/core/logstore/logstore.go
@@ -37,11 +37,17 @@ type Logstore interface {
 	// GetThread returns info about a thread.
 	GetThread(thread.ID) (thread.Info, error)
 
+	// DeleteThread deletes a thread.
+	DeleteThread(thread.ID) error
+
 	// AddLog adds a log to a thread.
 	AddLog(thread.ID, thread.LogInfo) error
 
 	// GetLog returns info about a log.
 	GetLog(thread.ID, peer.ID) (thread.LogInfo, error)
+
+	// DeleteLog deletes a log.
+	DeleteLog(thread.ID, peer.ID) error
 }
 
 // ThreadMetadata stores local thread metadata like name.
@@ -90,6 +96,12 @@ type KeyBook interface {
 
 	// AddServiceKey adds a service key under a thread.
 	AddServiceKey(thread.ID, *sym.Key) error
+
+	// ClearKeys deletes all keys under a thread.
+	ClearKeys(thread.ID) error
+
+	// ClearLogKeys deletes all keys under a log.
+	ClearLogKeys(thread.ID, peer.ID) error
 
 	// LogsWithKeys returns a list of log IDs for a service.
 	LogsWithKeys(thread.ID) (peer.IDSlice, error)

--- a/db/manager.go
+++ b/db/manager.go
@@ -135,9 +135,41 @@ func (m *Manager) NewDBFromAddr(ctx context.Context, addr ma.Multiaddr, key thre
 	return db, nil
 }
 
-// GetDB returns a db by id from the in-mem map.
+// GetDB returns a db by id.
 func (m *Manager) GetDB(id thread.ID) *DB {
 	return m.dbs[id]
+}
+
+// DeleteDB deletes a db by id.
+func (m *Manager) DeleteDB(ctx context.Context, id thread.ID) error {
+	db := m.dbs[id]
+	if db == nil {
+		return nil
+	}
+
+	if err := db.Close(); err != nil {
+		return err
+	}
+	if err := m.network.DeleteThread(ctx, id); err != nil {
+		return err
+	}
+
+	// Cleanup keys used by the db
+	pre := dsDBManagerBaseKey.ChildString(id.String())
+	q := query.Query{Prefix: pre.String(), KeysOnly: true}
+	results, err := m.config.Datastore.Query(q)
+	if err != nil {
+		return err
+	}
+	defer results.Close()
+	for result := range results.Next() {
+		if err := m.config.Datastore.Delete(ds.NewKey(result.Key)); err != nil {
+			return err
+		}
+	}
+
+	delete(m.dbs, id)
+	return nil
 }
 
 // Net returns the manager's thread network.
@@ -145,7 +177,7 @@ func (m *Manager) Net() net.Net {
 	return m.network
 }
 
-// Close all the in-mem dbs.
+// Close all dbs.
 func (m *Manager) Close() error {
 	for _, s := range m.dbs {
 		if err := s.Close(); err != nil {

--- a/db/manager_test.go
+++ b/db/manager_test.go
@@ -41,14 +41,14 @@ var (
 
 func TestManager_NewDB(t *testing.T) {
 	t.Parallel()
-	t.Run("Single", func(t *testing.T) {
+	t.Run("test one new db", func(t *testing.T) {
 		t.Parallel()
 		man, clean := createTestManager(t)
 		defer clean()
 		_, err := man.NewDB(context.Background(), thread.NewIDV1(thread.Raw, 32))
 		checkErr(t, err)
 	})
-	t.Run("Multiple", func(t *testing.T) {
+	t.Run("test multiple new dbs", func(t *testing.T) {
 		t.Parallel()
 		man, clean := createTestManager(t)
 		defer clean()
@@ -95,7 +95,7 @@ func TestManager_GetDB(t *testing.T) {
 	err = n.Close()
 	checkErr(t, err)
 
-	t.Run("GetHydrated", func(t *testing.T) {
+	t.Run("test get db after restart", func(t *testing.T) {
 		n, err := DefaultNetwork(dir)
 		checkErr(t, err)
 		man, err := NewManager(n, WithRepoPath(dir), WithJsonMode(true), WithDebug(true))
@@ -123,6 +123,32 @@ func TestManager_GetDB(t *testing.T) {
 		err = n.Close()
 		checkErr(t, err)
 	})
+}
+
+func TestManager_DeleteDB(t *testing.T) {
+	t.Parallel()
+	man, clean := createTestManager(t)
+	defer clean()
+
+	id := thread.NewIDV1(thread.Raw, 32)
+	db, err := man.NewDB(context.Background(), id)
+	checkErr(t, err)
+
+	// Register a schema and create an instance
+	collection, err := db.NewCollection(CollectionConfig{Name: "Person", Schema: jsonSchema})
+	checkErr(t, err)
+	person1 := `{"ID": "", "Name": "Foo", "Age": 21}`
+	err = collection.Create(&person1)
+	checkErr(t, err)
+
+	time.Sleep(time.Second)
+
+	err = man.DeleteDB(context.Background(), id)
+	checkErr(t, err)
+
+	if man.GetDB(id) != nil {
+		t.Fatal("db was not deleted")
+	}
 }
 
 func createTestManager(t *testing.T) (*Manager, func()) {

--- a/logstore/logstore.go
+++ b/logstore/logstore.go
@@ -3,6 +3,7 @@ package logstore
 import (
 	"fmt"
 	"io"
+	"sync"
 
 	"github.com/libp2p/go-libp2p-core/peer"
 	pstore "github.com/libp2p/go-libp2p-core/peerstore"
@@ -12,6 +13,8 @@ import (
 
 // logstore is a collection of books for storing thread logs.
 type logstore struct {
+	sync.RWMutex
+
 	core.KeyBook
 	core.AddrBook
 	core.ThreadMetadata
@@ -52,6 +55,9 @@ func (ls *logstore) Close() (err error) {
 
 // Threads returns a list of the thread IDs in the store.
 func (ls *logstore) Threads() (thread.IDSlice, error) {
+	ls.RLock()
+	defer ls.RUnlock()
+
 	set := map[thread.ID]struct{}{}
 	threadsFromKeys, err := ls.ThreadsFromKeys()
 	if err != nil {
@@ -72,12 +78,14 @@ func (ls *logstore) Threads() (thread.IDSlice, error) {
 	for t := range set {
 		ids = append(ids, t)
 	}
-
 	return ids, nil
 }
 
 // AddThread adds a thread with keys.
 func (ls *logstore) AddThread(info thread.Info) error {
+	ls.Lock()
+	defer ls.Unlock()
+
 	if info.Key.Service() == nil {
 		return fmt.Errorf("a service-key is required to add a thread")
 	}
@@ -94,6 +102,9 @@ func (ls *logstore) AddThread(info thread.Info) error {
 
 // GetThread returns thread info of the given id.
 func (ls *logstore) GetThread(id thread.ID) (info thread.Info, err error) {
+	ls.RLock()
+	defer ls.RUnlock()
+
 	sk, err := ls.ServiceKey(id)
 	if err != nil {
 		return
@@ -106,20 +117,9 @@ func (ls *logstore) GetThread(id thread.ID) (info thread.Info, err error) {
 		return
 	}
 
-	set := map[peer.ID]struct{}{}
-	logsWithKeys, err := ls.LogsWithKeys(id)
+	set, err := ls.getLogIDs(id)
 	if err != nil {
 		return
-	}
-	for _, l := range logsWithKeys {
-		set[l] = struct{}{}
-	}
-	logsWithAddrs, err := ls.LogsWithAddrs(id)
-	if err != nil {
-		return
-	}
-	for _, l := range logsWithAddrs {
-		set[l] = struct{}{}
 	}
 
 	logs := make([]thread.LogInfo, 0, len(set))
@@ -138,34 +138,77 @@ func (ls *logstore) GetThread(id thread.ID) (info thread.Info, err error) {
 	}, nil
 }
 
+func (ls *logstore) getLogIDs(id thread.ID) (map[peer.ID]struct{}, error) {
+	set := map[peer.ID]struct{}{}
+	logsWithKeys, err := ls.LogsWithKeys(id)
+	if err != nil {
+		return nil, err
+	}
+	for _, l := range logsWithKeys {
+		set[l] = struct{}{}
+	}
+	logsWithAddrs, err := ls.LogsWithAddrs(id)
+	if err != nil {
+		return nil, err
+	}
+	for _, l := range logsWithAddrs {
+		set[l] = struct{}{}
+	}
+	return set, nil
+}
+
+// DeleteThread deletes a thread.
+func (ls *logstore) DeleteThread(id thread.ID) error {
+	ls.Lock()
+	defer ls.Unlock()
+
+	if err := ls.ClearKeys(id); err != nil {
+		return err
+	}
+
+	set, err := ls.getLogIDs(id)
+	if err != nil {
+		return nil
+	}
+	for l := range set {
+		if err := ls.ClearAddrs(id, l); err != nil {
+			return err
+		}
+		if err := ls.ClearHeads(id, l); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // AddLog adds a log under the given thread.
 func (ls *logstore) AddLog(id thread.ID, lg thread.LogInfo) error {
+	ls.Lock()
+	defer ls.Unlock()
+
 	err := ls.AddPubKey(id, lg.ID, lg.PubKey)
 	if err != nil {
 		return err
 	}
-
 	if lg.PrivKey != nil {
-		err = ls.AddPrivKey(id, lg.ID, lg.PrivKey)
-		if err != nil {
+		if err = ls.AddPrivKey(id, lg.ID, lg.PrivKey); err != nil {
 			return err
 		}
 	}
-
-	err = ls.AddAddrs(id, lg.ID, lg.Addrs, pstore.PermanentAddrTTL)
-	if err != nil {
+	if err = ls.AddAddrs(id, lg.ID, lg.Addrs, pstore.PermanentAddrTTL); err != nil {
 		return err
 	}
-	err = ls.AddHeads(id, lg.ID, lg.Heads)
-	if err != nil {
+	if err = ls.AddHeads(id, lg.ID, lg.Heads); err != nil {
 		return err
 	}
-
 	return nil
 }
 
 // GetLog returns info about the given thread.
 func (ls *logstore) GetLog(id thread.ID, lid peer.ID) (info thread.LogInfo, err error) {
+	ls.RLock()
+	defer ls.RUnlock()
+
 	pk, err := ls.PubKey(id, lid)
 	if err != nil {
 		return
@@ -192,4 +235,21 @@ func (ls *logstore) GetLog(id thread.ID, lid peer.ID) (info thread.LogInfo, err 
 	info.Addrs = addrs
 	info.Heads = heads
 	return
+}
+
+// DeleteLog deletes a log.
+func (ls *logstore) DeleteLog(id thread.ID, lid peer.ID) (err error) {
+	ls.Lock()
+	defer ls.Unlock()
+
+	if err = ls.ClearLogKeys(id, lid); err != nil {
+		return
+	}
+	if err = ls.ClearAddrs(id, lid); err != nil {
+		return
+	}
+	if err = ls.ClearHeads(id, lid); err != nil {
+		return
+	}
+	return nil
 }

--- a/net/api/client/client_test.go
+++ b/net/api/client/client_test.go
@@ -125,7 +125,6 @@ func TestClient_PullThread(t *testing.T) {
 }
 
 func TestClient_DeleteThread(t *testing.T) {
-	t.Skip() // @todo: Thread deletes
 	t.Parallel()
 	_, client, done := setup(t)
 	defer done()
@@ -135,6 +134,9 @@ func TestClient_DeleteThread(t *testing.T) {
 	t.Run("test delete thread", func(t *testing.T) {
 		if err := client.DeleteThread(context.Background(), info.ID); err != nil {
 			t.Fatalf("failed to delete thread: %v", err)
+		}
+		if _, err := client.GetThread(context.Background(), info.ID); err == nil {
+			t.Fatal("thread was not deleted")
 		}
 	})
 }

--- a/net/net.go
+++ b/net/net.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"time"
 
+	sym "github.com/textileio/go-threads/crypto/symmetric"
+
 	"github.com/ipfs/go-cid"
 	bs "github.com/ipfs/go-ipfs-blockstore"
 	format "github.com/ipfs/go-ipld-format"
@@ -291,8 +293,8 @@ func (t *net) PullThread(ctx context.Context, id thread.ID) error {
 	return nil
 }
 
-// pullThread for new records. It's internal and *not* thread-safe,
-// it assumes we currently own the thread-lock.
+// pullThread for new records.
+// This method is internal and *not* thread-safe. It assumes we currently own the thread-lock.
 func (t *net) pullThread(ctx context.Context, id thread.ID) error {
 	info, err := t.store.GetThread(id)
 	if err != nil {
@@ -348,9 +350,47 @@ func (t *net) pullThread(ctx context.Context, id thread.ID) error {
 	return nil
 }
 
-// @todo
-func (t *net) DeleteThread(context.Context, thread.ID) error {
-	panic("implement me")
+func (t *net) DeleteThread(ctx context.Context, id thread.ID) error {
+	log.Debugf("deleting thread %s...", id.String())
+	ptl := t.getThreadSemaphore(id)
+	select {
+	case ptl <- struct{}{}:
+		err := t.deleteThread(ctx, id)
+		if err != nil {
+			<-ptl
+			return err
+		}
+		<-ptl
+	default:
+		log.Warnf("delete thread %s ignored since already being deleted", id)
+	}
+	return nil
+}
+
+// deleteThread cleans up all the persistent and in-memory bits of a thread. This includes:
+// - Removing all record and event nodes.
+// - Deleting all logstore keys, addresses, and heads.
+// - Deleting the thread semaphore.
+// Local and pubsub subscriptions will not be cancelled and will simply stop reporting.
+// This method is internal and *not* thread-safe. It assumes we currently own the thread-lock.
+func (t *net) deleteThread(ctx context.Context, id thread.ID) error {
+	info, err := t.store.GetThread(id)
+	if err != nil {
+		return err
+	}
+	for _, lg := range info.Logs { // Walk logs, removing record and event nodes
+		if len(lg.Heads) == 0 {
+			continue
+		}
+		head := lg.Heads[0]
+		for head.Defined() {
+			head, err = t.deleteRecord(ctx, head, info.Key.Service())
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return t.store.DeleteThread(id) // Delete logstore keys, addresses, and heads
 }
 
 func (t *net) AddReplicator(ctx context.Context, id thread.ID, paddr ma.Multiaddr) (pid peer.ID, err error) {
@@ -750,6 +790,25 @@ func (t *net) getLocalRecords(ctx context.Context, id thread.ID, lid peer.ID, of
 	}
 
 	return recs, nil
+}
+
+// deleteRecord remove a record from the dag service.
+func (t *net) deleteRecord(ctx context.Context, rid cid.Cid, sk *sym.Key) (prev cid.Cid, err error) {
+	rec, err := cbor.GetRecord(ctx, t, rid, sk)
+	if err != nil {
+		return
+	}
+	if err = cbor.RemoveRecord(ctx, t, rec); err != nil {
+		return
+	}
+	event, err := cbor.EventFromRecord(ctx, t, rec)
+	if err != nil {
+		return
+	}
+	if err = cbor.RemoveEvent(ctx, t, event); err != nil {
+		return
+	}
+	return rec.PrevID(), nil
 }
 
 // startPulling periodically pulls on all threads.


### PR DESCRIPTION
Closes #176 

- Adds `ClearKeys` and `ClearLogKeys` to `KeyBook`
- Adds `DeleteThread` and `DeleteLog` to `Logstore`
- Adds `RemoveRecord` and `RemoveEvent` in `cbor`
- Implements `DeleteThread` in `net`

To-do:
- [x] Add `DeleteThread` to the `net` API and client
- [x] Figure out how to delete a `DB` from `db.Manager`