### PR TITLE
Run foldersync tests separately

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,6 @@ jobs:
 
   test-foldersync:
     name: Foldersync Test
-    needs: [test]
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,33 @@ jobs:
         run: |
           go get -v -t -d ./...
       - name: Test
-        run: go test -race ./...
+        run: SKIP_FOLDERSYNC=true go test -race ./...
+
+  test-foldersync:
+    name: Foldersync Test
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.14
+      - name: Check out code
+        uses: actions/checkout@v1
+      - name: Cache dependencies
+        id: cache-dependencies
+        uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Get dependencies
+        if: steps.cache-dependencies.outputs.cache-hit != 'true'
+        run: |
+          go get -v -t -d ./...
+      - name: Test
+        run: go test ./integrationtests/foldersync/
 
   android-client:
     name: Android Client Test

--- a/integrationtests/foldersync/foldersync_test.go
+++ b/integrationtests/foldersync/foldersync_test.go
@@ -30,6 +30,10 @@ func TestMain(m *testing.M) {
 }
 
 func TestSimple(t *testing.T) {
+	if os.Getenv("SKIP_FOLDERSYNC") != "" {
+		t.Skip("Skipping foldersync tests")
+	}
+
 	id := thread.NewIDV1(thread.Raw, 32)
 
 	// db0
@@ -135,6 +139,9 @@ func TestSimple(t *testing.T) {
 }
 
 func TestNUsersBootstrap(t *testing.T) {
+	if os.Getenv("SKIP_FOLDERSYNC") != "" {
+		t.Skip("Skipping foldersync tests")
+	}
 	tests := []struct {
 		totalClients     int
 		totalCorePeers   int

--- a/integrationtests/foldersync/foldersync_test.go
+++ b/integrationtests/foldersync/foldersync_test.go
@@ -151,12 +151,12 @@ func TestNUsersBootstrap(t *testing.T) {
 		checkSyncedFiles bool
 	}{
 		{totalClients: 2, totalCorePeers: 1, syncTimeout: time.Second * 5},
-		// {totalClients: 3, totalCorePeers: 1, syncTimeout: time.Second * 15},
+		{totalClients: 3, totalCorePeers: 1, syncTimeout: time.Second * 15},
 
-		// {totalClients: 3, totalCorePeers: 2, syncTimeout: time.Second * 20},
+		{totalClients: 3, totalCorePeers: 2, syncTimeout: time.Second * 20},
 
 		{totalClients: 2, totalCorePeers: 1, syncTimeout: time.Second * 10, randFilesGen: 4, randFileSize: 10},
-		// {totalClients: 3, totalCorePeers: 2, syncTimeout: time.Second * 20, randFilesGen: 4, randFileSize: 10},
+		{totalClients: 3, totalCorePeers: 2, syncTimeout: time.Second * 20, randFilesGen: 4, randFileSize: 10},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Even though the folder sync tests themselves were running serially, I think they were still running in parallel with all the other tests. Here we try to run them in a completely separate CI step.