### PR TITLE
Lowercase instance ID

### DIFF
--- a/core/db/db.go
+++ b/core/db/db.go
@@ -2,10 +2,11 @@ package db
 
 import (
 	"crypto/rand"
+	"strings"
 
 	ds "github.com/ipfs/go-datastore"
 	format "github.com/ipfs/go-ipld-format"
-	"github.com/oklog/ulid/v2"
+	ulid "github.com/oklog/ulid/v2"
 )
 
 const (
@@ -19,7 +20,7 @@ type InstanceID string
 // NewInstanceID generates a new identity for an instance.
 func NewInstanceID() InstanceID {
 	id := ulid.MustNew(ulid.Now(), rand.Reader)
-	return InstanceID(id.String())
+	return InstanceID(strings.ToLower(id.String()))
 }
 
 func (e InstanceID) String() string {


### PR DESCRIPTION
Everything else is lower case... seems like this can be too. base32 in not case sensitive. 