### PR TITLE
fix(ux): change error string to indicate the correct missing field name

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -37,7 +37,7 @@ var (
 	log = logging.Logger("db")
 
 	// ErrInvalidCollectionSchema indicates the provided schema isn't valid for a Collection.
-	ErrInvalidCollectionSchema = errors.New("the collection schema should specify an ID string property")
+	ErrInvalidCollectionSchema = errors.New("the collection schema should specify an _id string property")
 
 	dsDBPrefix  = ds.NewKey("/db")
 	dsDBSchemas = dsDBPrefix.ChildString("schema")


### PR DESCRIPTION
`the collection schema should specify an ID string property` should be `the collection schema should specify an _id string property`