### PR TITLE
collections: allow missing id on create

### DIFF
--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -153,6 +153,26 @@ func TestClient_Create(t *testing.T) {
 			t.Fatalf("failed to create collection: %v", err)
 		}
 	})
+
+	t.Run("test collection create with missing id", func(t *testing.T) {
+		id := thread.NewIDV1(thread.Raw, 32)
+		err := client.NewDB(context.Background(), id)
+		checkErr(t, err)
+		err = client.NewCollection(context.Background(), id, db.CollectionConfig{Name: collectionName, Schema: util.SchemaFromSchemaString(schema)})
+		checkErr(t, err)
+
+		ids, err := client.Create(context.Background(), id, collectionName, Instances{&PersonWithoutID{
+			FirstName: "Adam",
+			LastName:  "Doe",
+			Age:       21,
+		}})
+		if err != nil {
+			t.Fatalf("failed to create collection: %v", err)
+		}
+		if len(ids) != 1 {
+			t.Fatal("expected a new id, got none")
+		}
+	})
 }
 
 func TestClient_Save(t *testing.T) {
@@ -693,7 +713,6 @@ const (
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "` + collectionName + `",
 	"type": "object",
-	"required": ["_id"],
 	"properties": {
 		"_id": {
 			"type": "string",
@@ -718,6 +737,12 @@ const (
 
 type Person struct {
 	ID        string `json:"_id"`
+	FirstName string `json:"firstName,omitempty"`
+	LastName  string `json:"lastName,omitempty"`
+	Age       int    `json:"age,omitempty"`
+}
+
+type PersonWithoutID struct {
 	FirstName string `json:"firstName,omitempty"`
 	LastName  string `json:"lastName,omitempty"`
 	Age       int    `json:"age,omitempty"`

--- a/db/collection.go
+++ b/db/collection.go
@@ -458,15 +458,15 @@ func (t *Txn) Discard() {
 	t.discarded = true
 }
 
-func getInstanceID(t []byte) (id core.InstanceID, err error) {
+func getInstanceID(t []byte) (core.InstanceID, error) {
 	partial := &struct {
 		ID *string `json:"_id"`
 	}{}
 	if err := json.Unmarshal(t, partial); err != nil {
-		return id, fmt.Errorf("error unmarshaling json instance: %v", err)
+		return core.EmptyInstanceID, fmt.Errorf("error unmarshaling json instance: %v", err)
 	}
 	if partial.ID == nil {
-		return id, errMissingInstanceID
+		return core.EmptyInstanceID, errMissingInstanceID
 	}
 	return core.InstanceID(*partial.ID), nil
 }


### PR DESCRIPTION
Closes #337 

Allows a `nil` `_id` attribute on instances that are being created.