### PR TITLE
util: fix typo in func name DefaultBootstrapPeers()

### DIFF
--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -642,7 +642,7 @@ func makeServer(t *testing.T) (ma.Multiaddr, func()) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	n.Bootstrap(util.DefaultBoostrapPeers())
+	n.Bootstrap(util.DefaultBootstrapPeers())
 	service, err := api.NewService(n, api.Config{
 		RepoPath: dir,
 		Debug:    true,

--- a/examples/chat/main.go
+++ b/examples/chat/main.go
@@ -101,7 +101,7 @@ func main() {
 		log.Fatal(err)
 	}
 	defer net.Close()
-	net.Bootstrap(util.DefaultBoostrapPeers())
+	net.Bootstrap(util.DefaultBootstrapPeers())
 
 	// Build a MDNS service
 	ctx = context.Background()

--- a/net/api/client/client_test.go
+++ b/net/api/client/client_test.go
@@ -419,7 +419,7 @@ func makeServer(t *testing.T) (ma.Multiaddr, ma.Multiaddr, func()) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	n.Bootstrap(util.DefaultBoostrapPeers())
+	n.Bootstrap(util.DefaultBootstrapPeers())
 	service, err := api.NewService(n, api.Config{
 		Debug: true,
 	})

--- a/threadsd/main.go
+++ b/threadsd/main.go
@@ -67,7 +67,7 @@ func main() {
 		log.Fatal(err)
 	}
 	defer n.Close()
-	n.Bootstrap(util.DefaultBoostrapPeers())
+	n.Bootstrap(util.DefaultBootstrapPeers())
 
 	service, err := api.NewService(n, api.Config{
 		RepoPath: *repo,

--- a/util/util.go
+++ b/util/util.go
@@ -92,7 +92,7 @@ func LoadKey(pth string) crypto.PrivKey {
 	return priv
 }
 
-func DefaultBoostrapPeers() []peer.AddrInfo {
+func DefaultBootstrapPeers() []peer.AddrInfo {
 	ais, err := ParseBootstrapPeers(bootstrapPeers)
 	if err != nil {
 		panic("coudn't parse default bootstrap peers")


### PR DESCRIPTION
While going over the `examples/chat/main.go` I noticed a innocent typo in the function name of `util/DefaultBootstrapPeers()` (was missing a t). If it's helpful, I've made the name change; if you feel it breaks interface and currently not helpful, no problem either!

PS: we started a new project and will be building on threads, so hopefully I'll be around with more in-depth contributions. thanks for the work!