### PR TITLE
Make thread.ID just a string alias

### DIFF
--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -165,7 +165,7 @@ func TestIt(t *testing.T) {
 
 	_, err = client.Create(context.Background(), id, collectionName, Instances{owner})
 	if err != nil {
-		t.Fatalf("failed to create collection: %v", err)
+		t.Fatalf("failed to create instance: %v", err)
 	}
 }
 

--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -150,7 +150,7 @@ func TestIt(t *testing.T) {
 	id := thread.NewIDV1(thread.Raw, 32)
 	err := client.NewDB(context.Background(), id)
 	checkErr(t, err)
-	sch := util.SchemaFromInstance(Owner{}, false)
+	sch := util.SchemaFromInstance(Owner{}, false, true)
 	schBytes, err := json.MarshalIndent(sch, "", "  ")
 	checkErr(t, err)
 	schStr := string(schBytes)
@@ -163,9 +163,21 @@ func TestIt(t *testing.T) {
 		ThreadID: id,
 	}
 
-	_, err = client.Create(context.Background(), id, collectionName, Instances{owner})
+	ids, err := client.Create(context.Background(), id, collectionName, Instances{owner})
 	if err != nil {
 		t.Fatalf("failed to create instance: %v", err)
+	}
+
+	another := &Owner{}
+
+	err = client.FindByID(context.Background(), id, collectionName, ids[0], another)
+	if err != nil {
+		t.Fatalf("failed to find instance: %v", err)
+	}
+	one := owner.ThreadID.String()
+	two := another.ThreadID.String()
+	if one != two {
+		t.Fatalf("thread id %v != %v", one, two)
 	}
 }
 

--- a/core/thread/id.go
+++ b/core/thread/id.go
@@ -86,7 +86,7 @@ var Undef = ID("")
 // Calling any other methods on an undefined ID will result in
 // undefined behavior.
 func (i ID) Defined() bool {
-	return i != Undef
+	return i != ""
 }
 
 // Decode parses an ID-encoded string and returns an ID object.

--- a/core/thread/id.go
+++ b/core/thread/id.go
@@ -86,7 +86,7 @@ var Undef = ID("")
 // Calling any other methods on an undefined ID will result in
 // undefined behavior.
 func (i ID) Defined() bool {
-	return i != ""
+	return i != Undef
 }
 
 // Decode parses an ID-encoded string and returns an ID object.

--- a/core/thread/id.go
+++ b/core/thread/id.go
@@ -294,6 +294,19 @@ func (i ID) Loggable() map[string]interface{} {
 	}
 }
 
+func (i ID) MarshalJSON() ([]byte, error) {
+	return i.Bytes(), nil
+}
+
+func (i *ID) UnmarshalJSON(data []byte) error {
+	id, err := Cast(data)
+	if err != nil {
+		return err
+	}
+	i.str = id.str
+	return nil
+}
+
 // IDSlice for sorting threads.
 type IDSlice []ID
 

--- a/core/thread/id.go
+++ b/core/thread/id.go
@@ -294,19 +294,6 @@ func (i ID) Loggable() map[string]interface{} {
 	}
 }
 
-func (i ID) MarshalJSON() ([]byte, error) {
-	return i.Bytes(), nil
-}
-
-func (i *ID) UnmarshalJSON(data []byte) error {
-	id, err := Cast(data)
-	if err != nil {
-		return err
-	}
-	i.str = id.str
-	return nil
-}
-
 // IDSlice for sorting threads.
 type IDSlice []ID
 

--- a/core/thread/id.go
+++ b/core/thread/id.go
@@ -3,6 +3,7 @@ package thread
 import (
 	"crypto/rand"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 
 	"github.com/ipfs/go-cid"
@@ -206,6 +207,19 @@ func (i *ID) UnmarshalText(text []byte) error {
 	return nil
 }
 
+func (i *ID) UnmarshalJSON(data []byte) error {
+	m := make(map[string]string)
+	if err := json.Unmarshal(data, &m); err != nil {
+		return err
+	}
+	val, err := Decode(m["str"])
+	if err != nil {
+		return err
+	}
+	i.str = val.str
+	return nil
+}
+
 // Version returns the ID version.
 func (i ID) Version() uint64 {
 	return V1
@@ -274,6 +288,13 @@ func (i ID) MarshalBinary() ([]byte, error) {
 // encoding.TextMarshaler interface.
 func (i ID) MarshalText() ([]byte, error) {
 	return []byte(i.String()), nil
+}
+
+func (i ID) MarshalJSON() ([]byte, error) {
+	data := map[string]string{
+		"str": i.String(),
+	}
+	return json.Marshal(data)
 }
 
 // Equals checks that two IDs are the same.

--- a/core/thread/id.go
+++ b/core/thread/id.go
@@ -70,23 +70,23 @@ func NewIDV1(variant Variant, size uint8) ID {
 		panic("copy length is inconsistent")
 	}
 
-	return ID(buf[:n+numlen])
+	return ID{string(buf[:n+numlen])}
 }
 
 // ID represents a self-describing thread identifier.
 // It is formed by a Version, a Variant, and a random number
 // of a given length.
-type ID string
+type ID struct{ str string }
 
 // Undef can be used to represent a nil or undefined Cid, using Cid{}
 // directly is also acceptable.
-var Undef = ID("")
+var Undef = ID{}
 
 // Defined returns true if an ID is defined.
 // Calling any other methods on an undefined ID will result in
 // undefined behavior.
 func (i ID) Defined() bool {
-	return i != ""
+	return i.str != ""
 }
 
 // Decode parses an ID-encoded string and returns an ID object.
@@ -152,7 +152,7 @@ func Cast(data []byte) (ID, error) {
 
 	id := data[n+cn:]
 
-	return ID(data[0 : n+cn+len(id)]), nil
+	return ID{string(data[0 : n+cn+len(id)])}, nil
 }
 
 // FromAddr returns ID from a multiaddress if present.
@@ -166,7 +166,7 @@ func FromAddr(addr ma.Multiaddr) (ID, error) {
 
 // ToAddr returns ID wrapped as a multiaddress.
 func ToAddr(id ID) ma.Multiaddr {
-	addr, err := ma.NewMultiaddr("/" + Name + "/ " + string(id))
+	addr, err := ma.NewMultiaddr("/" + Name + "/ " + id.str)
 	if err != nil {
 		panic(err) // This should not happen
 	}
@@ -191,7 +191,7 @@ func (i *ID) UnmarshalBinary(data []byte) error {
 	if err != nil {
 		return err
 	}
-	i = &casted
+	i.str = casted.str
 	return nil
 }
 
@@ -202,7 +202,7 @@ func (i *ID) UnmarshalText(text []byte) error {
 	if err != nil {
 		return err
 	}
-	i = &decodedID
+	i.str = decodedID.str
 	return nil
 }
 
@@ -213,8 +213,8 @@ func (i ID) Version() uint64 {
 
 // Variant returns the variant of an ID.
 func (i ID) Variant() Variant {
-	_, n := uvarint(string(i))
-	variant, _ := uvarint(string(i)[n:])
+	_, n := uvarint(i.str)
+	variant, _ := uvarint(i.str[n:])
 	return Variant(variant)
 }
 
@@ -223,7 +223,7 @@ func (i ID) Variant() Variant {
 func (i ID) String() string {
 	switch i.Version() {
 	case V1:
-		b := []byte(i)
+		b := []byte(i.str)
 		mbstr, err := mbase.Encode(mbase.Base32, b)
 		if err != nil {
 			panic("should not error with hardcoded mbase: " + err.Error())
@@ -261,7 +261,7 @@ func (i ID) Encode(base mbase.Encoder) string {
 // The output of bytes can be parsed back into an ID
 // with Cast().
 func (i ID) Bytes() []byte {
-	return []byte(i)
+	return []byte(i.str)
 }
 
 // MarshalBinary is equivalent to Bytes(). It implements the
@@ -283,7 +283,7 @@ func (i ID) Equals(o ID) bool {
 
 // KeyString returns the binary representation of the ID as a string.
 func (i ID) KeyString() string {
-	return string(i)
+	return i.str
 }
 
 // Loggable returns a Loggable (as defined by
@@ -299,7 +299,7 @@ type IDSlice []ID
 
 func (s IDSlice) Len() int           { return len(s) }
 func (s IDSlice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
-func (s IDSlice) Less(i, j int) bool { return s[i] < s[j] }
+func (s IDSlice) Less(i, j int) bool { return s[i].str < s[j].str }
 
 // Info holds thread logs, keys and addresses.
 type Info struct {

--- a/core/thread/id_test.go
+++ b/core/thread/id_test.go
@@ -1,6 +1,7 @@
 package thread
 
 import (
+	"encoding/json"
 	"testing"
 
 	mbase "github.com/multiformats/go-multibase"
@@ -58,4 +59,51 @@ func TestID_Variant(t *testing.T) {
 	}
 
 	t.Logf("Variant: %s", v)
+}
+
+func TestJSON(t *testing.T) {
+	i := NewIDV1(Raw, 32)
+	t.Logf("New ID: %s", i.String())
+
+	data, err := i.MarshalJSON()
+	if err != nil {
+		t.Errorf("failed to marshal ID %s: %s", i.String(), err)
+	}
+
+	i2 := ID{}
+	err = i2.UnmarshalJSON(data)
+	if err != nil {
+		t.Errorf("failed to unmarshal ID: %s", err)
+	}
+
+	if i.str != i2.str {
+		t.Errorf("ID string %s != %s", i.str, i2.str)
+	}
+}
+
+func TestNestedJSON(t *testing.T) {
+
+	type Person struct {
+		ThreadID ID
+	}
+
+	i := NewIDV1(Raw, 32)
+	t.Logf("New ID: %s", i.String())
+
+	p1 := Person{ThreadID: i}
+
+	data, err := json.Marshal(p1)
+	if err != nil {
+		t.Errorf("failed to marshal Person: %s", err)
+	}
+
+	p2 := &Person{}
+	err = json.Unmarshal(data, p2)
+	if err != nil {
+		t.Errorf("failed to unmarshal Person: %s", err)
+	}
+
+	if p1.ThreadID.str != p2.ThreadID.str {
+		t.Errorf("Person ID string %s != %s", p1.ThreadID.str, p2.ThreadID.str)
+	}
 }

--- a/core/thread/id_test.go
+++ b/core/thread/id_test.go
@@ -61,28 +61,7 @@ func TestID_Variant(t *testing.T) {
 	t.Logf("Variant: %s", v)
 }
 
-func TestJSON(t *testing.T) {
-	i := NewIDV1(Raw, 32)
-	t.Logf("New ID: %s", i.String())
-
-	data, err := i.MarshalJSON()
-	if err != nil {
-		t.Errorf("failed to marshal ID %s: %s", i.String(), err)
-	}
-
-	i2 := ID{}
-	err = i2.UnmarshalJSON(data)
-	if err != nil {
-		t.Errorf("failed to unmarshal ID: %s", err)
-	}
-
-	if i.str != i2.str {
-		t.Errorf("ID string %s != %s", i.str, i2.str)
-	}
-}
-
 func TestNestedJSON(t *testing.T) {
-
 	type Person struct {
 		ThreadID ID
 	}

--- a/db/collection_test.go
+++ b/db/collection_test.go
@@ -43,7 +43,7 @@ func TestNewCollection(t *testing.T) {
 		defer clean()
 		_, err := db.NewCollection(CollectionConfig{
 			Name:   "Dog",
-			Schema: util.SchemaFromInstance(&Dog{}, false),
+			Schema: util.SchemaFromInstance(&Dog{}, false, false),
 		})
 		checkErr(t, err)
 	})
@@ -53,7 +53,7 @@ func TestNewCollection(t *testing.T) {
 		defer clean()
 		_, err := db.NewCollection(CollectionConfig{
 			Name:   "Dog",
-			Schema: util.SchemaFromInstance(&Dog{}, true),
+			Schema: util.SchemaFromInstance(&Dog{}, true, false),
 		})
 		checkErr(t, err)
 	})
@@ -63,12 +63,12 @@ func TestNewCollection(t *testing.T) {
 		defer clean()
 		_, err := db.NewCollection(CollectionConfig{
 			Name:   "Dog",
-			Schema: util.SchemaFromInstance(&Dog{}, false),
+			Schema: util.SchemaFromInstance(&Dog{}, false, false),
 		})
 		checkErr(t, err)
 		_, err = db.NewCollection(CollectionConfig{
 			Name:   "Person",
-			Schema: util.SchemaFromInstance(&Person{}, false),
+			Schema: util.SchemaFromInstance(&Person{}, false, false),
 		})
 		checkErr(t, err)
 	})
@@ -81,7 +81,7 @@ func TestNewCollection(t *testing.T) {
 		defer clean()
 		cc := CollectionConfig{
 			Name:   "FailingType",
-			Schema: util.SchemaFromInstance(&FailingType{}, false),
+			Schema: util.SchemaFromInstance(&FailingType{}, false, false),
 		}
 		if _, err := db.NewCollection(cc); err != ErrInvalidCollectionSchema {
 			t.Fatal("the collection should be invalid")
@@ -93,7 +93,7 @@ func TestNewCollection(t *testing.T) {
 		defer clean()
 		cc := CollectionConfig{
 			Name:   "FailingType",
-			Schema: util.SchemaFromInstance(&FailingType{}, true),
+			Schema: util.SchemaFromInstance(&FailingType{}, true, false),
 		}
 		if _, err := db.NewCollection(cc); err != ErrInvalidCollectionSchema {
 			t.Fatal("the collection should be invalid")
@@ -105,7 +105,7 @@ func TestNewCollection(t *testing.T) {
 		defer clean()
 		cc := CollectionConfig{
 			Name:   "Not a URL-safe name",
-			Schema: util.SchemaFromInstance(&Dog{}, false),
+			Schema: util.SchemaFromInstance(&Dog{}, false, false),
 		}
 		if _, err := db.NewCollection(cc); err != ErrInvalidCollectionName {
 			t.Fatal("the collection name should be invalid")
@@ -121,7 +121,7 @@ func TestAddIndex(t *testing.T) {
 		defer clean()
 		collection, err := db.NewCollection(CollectionConfig{
 			Name:   "Person",
-			Schema: util.SchemaFromInstance(&Person{}, false),
+			Schema: util.SchemaFromInstance(&Person{}, false, false),
 		})
 		checkErr(t, err)
 
@@ -148,7 +148,7 @@ func TestCreateInstance(t *testing.T) {
 		defer clean()
 		collection, err := db.NewCollection(CollectionConfig{
 			Name:   "Person",
-			Schema: util.SchemaFromInstance(&Person{}, false),
+			Schema: util.SchemaFromInstance(&Person{}, false, false),
 		})
 		checkErr(t, err)
 
@@ -177,7 +177,7 @@ func TestCreateInstance(t *testing.T) {
 		defer clean()
 		collection, err := db.NewCollection(CollectionConfig{
 			Name:   "Person",
-			Schema: util.SchemaFromInstance(&Person{}, false),
+			Schema: util.SchemaFromInstance(&Person{}, false, false),
 		})
 		checkErr(t, err)
 
@@ -205,7 +205,7 @@ func TestCreateInstance(t *testing.T) {
 		defer clean()
 		collection, err := db.NewCollection(CollectionConfig{
 			Name:   "Person",
-			Schema: util.SchemaFromInstance(&Person{}, false),
+			Schema: util.SchemaFromInstance(&Person{}, false, false),
 		})
 		checkErr(t, err)
 
@@ -227,7 +227,7 @@ func TestCreateInstance(t *testing.T) {
 		defer clean()
 		m, err := db.NewCollection(CollectionConfig{
 			Name:   "Person",
-			Schema: util.SchemaFromInstance(&Person{}, false),
+			Schema: util.SchemaFromInstance(&Person{}, false, false),
 		})
 		checkErr(t, err)
 
@@ -251,7 +251,7 @@ func TestReadTxnValidation(t *testing.T) {
 		defer clean()
 		m, err := db.NewCollection(CollectionConfig{
 			Name:   "Person",
-			Schema: util.SchemaFromInstance(&Person{}, false),
+			Schema: util.SchemaFromInstance(&Person{}, false, false),
 		})
 		checkErr(t, err)
 		err = m.ReadTxn(func(txn *Txn) error {
@@ -268,7 +268,7 @@ func TestReadTxnValidation(t *testing.T) {
 		defer clean()
 		m, err := db.NewCollection(CollectionConfig{
 			Name:   "Person",
-			Schema: util.SchemaFromInstance(&Person{}, false),
+			Schema: util.SchemaFromInstance(&Person{}, false, false),
 		})
 		checkErr(t, err)
 		p := util.JSONFromInstance(Person{Name: "Foo1", Age: 42})
@@ -288,7 +288,7 @@ func TestReadTxnValidation(t *testing.T) {
 		defer clean()
 		m, err := db.NewCollection(CollectionConfig{
 			Name:   "Person",
-			Schema: util.SchemaFromInstance(&Person{}, false),
+			Schema: util.SchemaFromInstance(&Person{}, false, false),
 		})
 		checkErr(t, err)
 		p := util.JSONFromInstance(Person{Name: "Foo1", Age: 42})
@@ -310,7 +310,7 @@ func TestVariadic(t *testing.T) {
 	defer clean()
 	m, err := db.NewCollection(CollectionConfig{
 		Name:   "Person",
-		Schema: util.SchemaFromInstance(&Person{}, false),
+		Schema: util.SchemaFromInstance(&Person{}, false, false),
 	})
 	checkErr(t, err)
 
@@ -357,7 +357,7 @@ func TestGetInstance(t *testing.T) {
 	defer clean()
 	collection, err := db.NewCollection(CollectionConfig{
 		Name:   "Person",
-		Schema: util.SchemaFromInstance(&Person{}, false),
+		Schema: util.SchemaFromInstance(&Person{}, false, false),
 	})
 	checkErr(t, err)
 
@@ -424,7 +424,7 @@ func TestSaveInstance(t *testing.T) {
 		defer clean()
 		collection, err := db.NewCollection(CollectionConfig{
 			Name:   "Person",
-			Schema: util.SchemaFromInstance(&Person{}, false),
+			Schema: util.SchemaFromInstance(&Person{}, false, false),
 		})
 		checkErr(t, err)
 
@@ -462,7 +462,7 @@ func TestSaveInstance(t *testing.T) {
 		defer clean()
 		m, err := db.NewCollection(CollectionConfig{
 			Name:   "Person",
-			Schema: util.SchemaFromInstance(&Person{}, false),
+			Schema: util.SchemaFromInstance(&Person{}, false, false),
 		})
 		checkErr(t, err)
 
@@ -480,7 +480,7 @@ func TestDeleteInstance(t *testing.T) {
 	defer clean()
 	collection, err := db.NewCollection(CollectionConfig{
 		Name:   "Person",
-		Schema: util.SchemaFromInstance(&Person{}, false),
+		Schema: util.SchemaFromInstance(&Person{}, false, false),
 	})
 	checkErr(t, err)
 
@@ -521,7 +521,7 @@ func TestInvalidActions(t *testing.T) {
 	defer clean()
 	collection, err := db.NewCollection(CollectionConfig{
 		Name:   "Person",
-		Schema: util.SchemaFromInstance(&Person{}, false),
+		Schema: util.SchemaFromInstance(&Person{}, false, false),
 	})
 	checkErr(t, err)
 	t.Run("Create", func(t *testing.T) {

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -36,7 +36,7 @@ func TestE2EWithThreads(t *testing.T) {
 	defer d1.Close()
 	c1, err := d1.NewCollection(CollectionConfig{
 		Name:   "dummy",
-		Schema: util.SchemaFromInstance(&dummy{}, false),
+		Schema: util.SchemaFromInstance(&dummy{}, false, false),
 	})
 	checkErr(t, err)
 	dummyJSON := util.JSONFromInstance(dummy{Name: "Textile", Counter: 0})
@@ -68,7 +68,7 @@ func TestE2EWithThreads(t *testing.T) {
 	checkErr(t, err)
 	cc := CollectionConfig{
 		Name:   "dummy",
-		Schema: util.SchemaFromInstance(&dummy{}, false),
+		Schema: util.SchemaFromInstance(&dummy{}, false, false),
 	}
 	d2, err := NewDBFromAddr(context.Background(), n2, addr, ti.Key, WithNewDBRepoPath(tmpDir2), WithNewDBCollections(cc))
 	checkErr(t, err)
@@ -107,7 +107,7 @@ func TestOptions(t *testing.T) {
 
 	m, err := d.NewCollection(CollectionConfig{
 		Name:   "dummy",
-		Schema: util.SchemaFromInstance(&dummy{}, false),
+		Schema: util.SchemaFromInstance(&dummy{}, false, false),
 	})
 	checkErr(t, err)
 	_, err = m.Create(util.JSONFromInstance(dummy{Name: "Textile"}))
@@ -258,13 +258,13 @@ func runListenersComplexUseCase(t *testing.T, los ...ListenOption) []Action {
 	d, cls := createTestDB(t)
 	cc1 := CollectionConfig{
 		Name:   "Collection1",
-		Schema: util.SchemaFromInstance(&dummy{}, false),
+		Schema: util.SchemaFromInstance(&dummy{}, false, false),
 	}
 	c1, err := d.NewCollection(cc1)
 	checkErr(t, err)
 	cc2 := CollectionConfig{
 		Name:   "Collection2",
-		Schema: util.SchemaFromInstance(&dummy{}, false),
+		Schema: util.SchemaFromInstance(&dummy{}, false, false),
 	}
 	c2, err := d.NewCollection(cc2)
 	checkErr(t, err)

--- a/db/query_more_test.go
+++ b/db/query_more_test.go
@@ -150,7 +150,7 @@ func createCollectionWithData(t *testing.T) (*Collection, []book, func()) {
 	db, clean := createTestDB(t)
 	c, err := db.NewCollection(CollectionConfig{
 		Name:   "Book",
-		Schema: util.SchemaFromInstance(&book{}, false),
+		Schema: util.SchemaFromInstance(&book{}, false, false),
 	})
 	checkErr(t, err)
 	sampleDataCopy := make([]book, len(sampleData))

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -310,7 +310,7 @@ func createCollectionWithJSONData(t *testing.T) (*Collection, []Book, func()) {
 	s, clean := createTestDB(t)
 	c, err := s.NewCollection(CollectionConfig{
 		Name:   "Book",
-		Schema: util.SchemaFromInstance(&Book{}, false),
+		Schema: util.SchemaFromInstance(&Book{}, false, false),
 		Indexes: []IndexConfig{
 			{
 				Path: "Meta.TotalReads",

--- a/examples/e2e_counter/reader.go
+++ b/examples/e2e_counter/reader.go
@@ -23,7 +23,7 @@ func runReaderPeer(repo string) {
 
 	cc := db.CollectionConfig{
 		Name:   "counter",
-		Schema: util.SchemaFromInstance(&myCounter{}, false),
+		Schema: util.SchemaFromInstance(&myCounter{}, false, false),
 	}
 
 	d, err := db.NewDBFromAddr(context.Background(), n, writerAddr, key, db.WithNewDBRepoPath(repo), db.WithNewDBCollections(cc))

--- a/examples/e2e_counter/writer.go
+++ b/examples/e2e_counter/writer.go
@@ -34,7 +34,7 @@ func runWriterPeer(repo string) {
 
 	m, err := d.NewCollection(db.CollectionConfig{
 		Name:   "counter",
-		Schema: util.SchemaFromInstance(&myCounter{}, false),
+		Schema: util.SchemaFromInstance(&myCounter{}, false, false),
 	})
 	checkErr(err)
 

--- a/examples/local_eventstore/books/main.go
+++ b/examples/local_eventstore/books/main.go
@@ -31,7 +31,7 @@ func main() {
 
 	collection, err := d.NewCollection(db.CollectionConfig{
 		Name:   "Book",
-		Schema: util.SchemaFromInstance(&book{}, false),
+		Schema: util.SchemaFromInstance(&book{}, false, false),
 	})
 	checkErr(err)
 

--- a/integrationtests/foldersync/client.go
+++ b/integrationtests/foldersync/client.go
@@ -33,7 +33,7 @@ var (
 
 	cc = db.CollectionConfig{
 		Name:   collectionName,
-		Schema: util.SchemaFromInstance(folder{}, false),
+		Schema: util.SchemaFromInstance(folder{}, false, false),
 	}
 
 	errClientAlreadyStarted = errors.New("client already started")

--- a/util/util.go
+++ b/util/util.go
@@ -144,8 +144,8 @@ func FreeLocalAddr() ma.Multiaddr {
 	return MustParseAddr(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", hostPort))
 }
 
-func SchemaFromInstance(i interface{}, expandedStruct bool) *jsonschema.Schema {
-	reflector := jsonschema.Reflector{ExpandedStruct: expandedStruct}
+func SchemaFromInstance(i interface{}, expandedStruct bool, additionalProperties bool) *jsonschema.Schema {
+	reflector := jsonschema.Reflector{ExpandedStruct: expandedStruct, AllowAdditionalProperties: additionalProperties}
 	return reflector.Reflect(i)
 }
 


### PR DESCRIPTION
Instead of a struct. The inner `str` property was private and therefore, not serializable to json. This cropped up as a problem when @Schwartz10 started trying to store thread ids in a collection. This will likely be a common thing to do.

The options were to make `str` public `Str` or to just make `thread.ID` an alias for `string`. I went with the later because it's more simple and consistent with our instance id type.