### PR TITLE
Copy of Make thread.ID just a string alias

### DIFF
--- a/.github/workflows/publish-grpc-libs.yml
+++ b/.github/workflows/publish-grpc-libs.yml
@@ -34,7 +34,7 @@ jobs:
           node-version: '12.x'
           registry-url: 'https://registry.npmjs.org'
       - name: Install protoc
-        uses: Arduino/actions/setup-protoc@master
+        uses: arduino/setup-protoc@master
         with:
           version: '3.11.2'
       - name: Install Go protoc plugins

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           java-version: 1.8
       - name: Install protoc
-        uses: Arduino/actions/setup-protoc@master
+        uses: arduino/setup-protoc@master
         with:
           version: '3.11.2'
       - name: Install Android SDK

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           java-version: 1.8
       - name: Install protoc
-        uses: Arduino/actions/setup-protoc@master
+        uses: arduino/setup-protoc@master
         with:
           version: '3.11.2'
       - name: Install Android SDK

--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -90,7 +90,7 @@ func TestClient_GetDBInfo(t *testing.T) {
 
 		addrs, key, err := client.GetDBInfo(context.Background(), id)
 		if err != nil {
-			t.Fatalf("failed to create collection: %v", err)
+			t.Fatalf("failed to get db info: %v", err)
 		}
 		if !key.Defined() {
 			t.Fatal("got undefined db key")
@@ -131,7 +131,7 @@ func TestClient_NewCollection(t *testing.T) {
 		checkErr(t, err)
 		err = client.NewCollection(context.Background(), id, db.CollectionConfig{Name: collectionName, Schema: util.SchemaFromSchemaString(schema)})
 		if err != nil {
-			t.Fatalf("failed add new collection: %v", err)
+			t.Fatalf("failed to add new collection: %v", err)
 		}
 	})
 }
@@ -150,7 +150,7 @@ func TestClient_Create(t *testing.T) {
 
 		_, err = client.Create(context.Background(), id, collectionName, Instances{createPerson()})
 		if err != nil {
-			t.Fatalf("failed to create collection: %v", err)
+			t.Fatalf("failed to create instance: %v", err)
 		}
 	})
 
@@ -167,7 +167,7 @@ func TestClient_Create(t *testing.T) {
 			Age:       21,
 		}})
 		if err != nil {
-			t.Fatalf("failed to create collection: %v", err)
+			t.Fatalf("failed to create instance: %v", err)
 		}
 		if len(ids) != 1 {
 			t.Fatal("expected a new id, got none")
@@ -196,7 +196,7 @@ func TestClient_Save(t *testing.T) {
 		person.Age = 30
 		err = client.Save(context.Background(), id, collectionName, Instances{person})
 		if err != nil {
-			t.Fatalf("failed to save collection: %v", err)
+			t.Fatalf("failed to save instance: %v", err)
 		}
 	})
 }
@@ -222,7 +222,7 @@ func TestClient_Delete(t *testing.T) {
 
 		err = client.Delete(context.Background(), id, collectionName, []string{person.ID})
 		if err != nil {
-			t.Fatalf("failed to delete collection: %v", err)
+			t.Fatalf("failed to delete instance: %v", err)
 		}
 	})
 }

--- a/core/thread/id.go
+++ b/core/thread/id.go
@@ -187,22 +187,22 @@ func uvError(read int) error {
 // UnmarshalBinary is equivalent to Cast(). It implements the
 // encoding.BinaryUnmarshaler interface.
 func (i *ID) UnmarshalBinary(data []byte) error {
-	casted, err := Cast(data)
+	id, err := Cast(data)
 	if err != nil {
 		return err
 	}
-	i = &casted
+	*i = id
 	return nil
 }
 
 // UnmarshalText is equivalent to Decode(). It implements the
 // encoding.TextUnmarshaler interface.
 func (i *ID) UnmarshalText(text []byte) error {
-	decodedID, err := Decode(string(text))
+	id, err := Decode(string(text))
 	if err != nil {
 		return err
 	}
-	i = &decodedID
+	*i = id
 	return nil
 }
 

--- a/core/thread/id.go
+++ b/core/thread/id.go
@@ -86,7 +86,7 @@ var Undef = ID("")
 // Calling any other methods on an undefined ID will result in
 // undefined behavior.
 func (i ID) Defined() bool {
-	return i != ""
+	return i != Undef
 }
 
 // Decode parses an ID-encoded string and returns an ID object.

--- a/core/thread/id.go
+++ b/core/thread/id.go
@@ -253,6 +253,9 @@ func (i ID) Variant() Variant {
 // String returns the default string representation of an ID.
 // Currently, Base32 is used as the encoding for the multibase string.
 func (i ID) String() string {
+	if !i.Valid() {
+		panic("invalid thread id")
+	}
 	switch i.Version() {
 	case V1:
 		b := []byte(i)
@@ -270,6 +273,9 @@ func (i ID) String() string {
 // String returns the string representation of an ID
 // encoded is selected base.
 func (i ID) StringOfBase(base mbase.Encoding) (string, error) {
+	if !i.Valid() {
+		panic("invalid thread id")
+	}
 	switch i.Version() {
 	case V1:
 		return mbase.Encode(base, i.Bytes())
@@ -281,6 +287,9 @@ func (i ID) StringOfBase(base mbase.Encoding) (string, error) {
 // Encode return the string representation of an ID in a given base
 // when applicable.
 func (i ID) Encode(base mbase.Encoder) string {
+	if !i.Valid() {
+		panic("invalid thread id")
+	}
 	switch i.Version() {
 	case V1:
 		return base.Encode(i.Bytes())
@@ -305,6 +314,9 @@ func (i ID) MarshalBinary() ([]byte, error) {
 // MarshalText is equivalent to String(). It implements the
 // encoding.TextMarshaler interface.
 func (i ID) MarshalText() ([]byte, error) {
+	if !i.Valid() {
+		return nil, fmt.Errorf("invalid thread id")
+	}
 	return []byte(i.String()), nil
 }
 

--- a/core/thread/id.go
+++ b/core/thread/id.go
@@ -171,10 +171,9 @@ func uvError(read int) error {
 	}
 }
 
-func (i ID) Valid() bool {
+func (i ID) Validate() error {
 	data := i.Bytes()
-	err := validateIDData(data)
-	return err == nil
+	return validateIDData(data)
 }
 
 func getVersion(data []byte) (uint64, int, error) {
@@ -253,7 +252,7 @@ func (i ID) Variant() Variant {
 // String returns the default string representation of an ID.
 // Currently, Base32 is used as the encoding for the multibase string.
 func (i ID) String() string {
-	if !i.Valid() {
+	if err := i.Validate(); err != nil {
 		panic("invalid thread id")
 	}
 	switch i.Version() {
@@ -273,7 +272,7 @@ func (i ID) String() string {
 // String returns the string representation of an ID
 // encoded is selected base.
 func (i ID) StringOfBase(base mbase.Encoding) (string, error) {
-	if !i.Valid() {
+	if err := i.Validate(); err != nil {
 		panic("invalid thread id")
 	}
 	switch i.Version() {
@@ -287,7 +286,7 @@ func (i ID) StringOfBase(base mbase.Encoding) (string, error) {
 // Encode return the string representation of an ID in a given base
 // when applicable.
 func (i ID) Encode(base mbase.Encoder) string {
-	if !i.Valid() {
+	if err := i.Validate(); err != nil {
 		panic("invalid thread id")
 	}
 	switch i.Version() {
@@ -314,8 +313,8 @@ func (i ID) MarshalBinary() ([]byte, error) {
 // MarshalText is equivalent to String(). It implements the
 // encoding.TextMarshaler interface.
 func (i ID) MarshalText() ([]byte, error) {
-	if !i.Valid() {
-		return nil, fmt.Errorf("invalid thread id")
+	if err := i.Validate(); err != nil {
+		panic("invalid thread id")
 	}
 	return []byte(i.String()), nil
 }

--- a/core/thread/id_test.go
+++ b/core/thread/id_test.go
@@ -1,10 +1,23 @@
 package thread
 
 import (
+	"crypto/rand"
+	"encoding/binary"
 	"testing"
 
 	mbase "github.com/multiformats/go-multibase"
 )
+
+func TestCast(t *testing.T) {
+	i := NewIDV1(Raw, 32)
+	j, err := Cast(i.Bytes())
+	if err != nil {
+		t.Errorf("failed to cast ID %s: %s", i.String(), err)
+	}
+	if i != j {
+		t.Errorf("id %v not equal to id %v", i.String(), j.String())
+	}
+}
 
 func TestDecode(t *testing.T) {
 	i := NewIDV1(Raw, 32)
@@ -58,4 +71,52 @@ func TestID_Variant(t *testing.T) {
 	}
 
 	t.Logf("Variant: %s", v)
+}
+
+func TestID_Valid(t *testing.T) {
+	i := NewIDV1(Raw, 16)
+	valid := i.Valid()
+	if !valid {
+		t.Errorf("id %s is invalid", i.String())
+	}
+}
+
+func TestID_Invalid(t *testing.T) {
+	i := makeID(t, 5, int64(Raw), 16)
+	valid := i.Valid()
+	if valid {
+		t.Errorf("id %s is valid but it has an invalid version", i.String())
+	}
+
+	i = makeID(t, V1, 50, 16)
+	valid = i.Valid()
+	if valid {
+		t.Errorf("id %s is valid but it has an invalid variant", i.String())
+	}
+
+	i = makeID(t, V1, int64(Raw), 0)
+	valid = i.Valid()
+	if valid {
+		t.Errorf("id %s is valid but it has no random bytes", i.String())
+	}
+}
+
+func makeID(t *testing.T, version uint64, variant int64, size uint8) ID {
+	num := make([]byte, size)
+	_, err := rand.Read(num)
+	if err != nil {
+		t.Errorf("failed to generate random data: %v", err)
+	}
+
+	numlen := len(num)
+	// two 8 bytes (max) numbers plus num
+	buf := make([]byte, 2*binary.MaxVarintLen64+numlen)
+	n := binary.PutUvarint(buf, version)
+	n += binary.PutUvarint(buf[n:], uint64(variant))
+	cn := copy(buf[n:], num)
+	if cn != numlen {
+		t.Errorf("copy length is inconsistent")
+	}
+
+	return ID(buf[:n+numlen])
 }

--- a/core/thread/id_test.go
+++ b/core/thread/id_test.go
@@ -45,10 +45,6 @@ func TestExtractEncoding(t *testing.T) {
 func TestID_Version(t *testing.T) {
 	i := NewIDV1(Raw, 16)
 
-	if !i.Valid() {
-		t.Errorf("invalid thread id")
-	}
-
 	v := i.Version()
 	if v != V1 {
 		t.Errorf("got wrong version from %s: %d", i.String(), v)

--- a/core/thread/id_test.go
+++ b/core/thread/id_test.go
@@ -45,6 +45,10 @@ func TestExtractEncoding(t *testing.T) {
 func TestID_Version(t *testing.T) {
 	i := NewIDV1(Raw, 16)
 
+	if !i.Valid() {
+		t.Errorf("invalid thread id")
+	}
+
 	v := i.Version()
 	if v != V1 {
 		t.Errorf("got wrong version from %s: %d", i.String(), v)

--- a/core/thread/id_test.go
+++ b/core/thread/id_test.go
@@ -75,28 +75,24 @@ func TestID_Variant(t *testing.T) {
 
 func TestID_Valid(t *testing.T) {
 	i := NewIDV1(Raw, 16)
-	valid := i.Valid()
-	if !valid {
+	if err := i.Validate(); err != nil {
 		t.Errorf("id %s is invalid", i.String())
 	}
 }
 
 func TestID_Invalid(t *testing.T) {
 	i := makeID(t, 5, int64(Raw), 16)
-	valid := i.Valid()
-	if valid {
+	if err := i.Validate(); err == nil {
 		t.Errorf("id %s is valid but it has an invalid version", i.String())
 	}
 
 	i = makeID(t, V1, 50, 16)
-	valid = i.Valid()
-	if valid {
+	if err := i.Validate(); err == nil {
 		t.Errorf("id %s is valid but it has an invalid variant", i.String())
 	}
 
 	i = makeID(t, V1, int64(Raw), 0)
-	valid = i.Valid()
-	if valid {
+	if err := i.Validate(); err == nil {
 		t.Errorf("id %s is valid but it has no random bytes", i.String())
 	}
 }

--- a/core/thread/protocol.go
+++ b/core/thread/protocol.go
@@ -45,8 +45,8 @@ func threadBtS(b []byte) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if !m.Valid() {
-		return "", fmt.Errorf("invalid thread id")
+	if err := m.Validate(); err != nil {
+		return "", err
 	}
 	return m.String(), nil
 }

--- a/core/thread/protocol.go
+++ b/core/thread/protocol.go
@@ -45,6 +45,9 @@ func threadBtS(b []byte) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if !m.Valid() {
+		return "", fmt.Errorf("invalid thread id")
+	}
 	return m.String(), nil
 }
 

--- a/db/manager.go
+++ b/db/manager.go
@@ -195,8 +195,8 @@ func (m *Manager) DeleteDB(ctx context.Context, id thread.ID, opts ...ManagedDBO
 	}
 
 	// Cleanup keys used by the db
-	if !id.Valid() {
-		return fmt.Errorf("invalid thread id")
+	if err := id.Validate(); err != nil {
+		return err
 	}
 	pre := dsDBManagerBaseKey.ChildString(id.String())
 	q := query.Query{Prefix: pre.String(), KeysOnly: true}
@@ -234,8 +234,8 @@ func (m *Manager) Close() error {
 // wraps the datastore with an id prefix,
 // and merges specified collection configs with those from base
 func getDBOptions(id thread.ID, base *NewDBOptions, collections ...CollectionConfig) (*NewDBOptions, error) {
-	if !id.Valid() {
-		return nil, fmt.Errorf("invalid thread id")
+	if err := id.Validate(); err != nil {
+		return nil, err
 	}
 	return &NewDBOptions{
 		RepoPath: base.RepoPath,

--- a/db/manager.go
+++ b/db/manager.go
@@ -80,7 +80,11 @@ func NewManager(network app.Net, opts ...NewDBOption) (*Manager, error) {
 		if _, ok := m.dbs[id]; ok {
 			continue
 		}
-		s, err := newDB(m.network, id, getDBOptions(id, m.newDBOptions))
+		opts, err := getDBOptions(id, m.newDBOptions)
+		if err != nil {
+			return nil, err
+		}
+		s, err := newDB(m.network, id, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -107,7 +111,11 @@ func (m *Manager) NewDB(ctx context.Context, id thread.ID, opts ...NewManagedDBO
 		return nil, err
 	}
 
-	db, err := newDB(m.network, id, getDBOptions(id, m.newDBOptions, args.Collections...))
+	dbOpts, err := getDBOptions(id, m.newDBOptions, args.Collections...)
+	if err != nil {
+		return nil, err
+	}
+	db, err := newDB(m.network, id, dbOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +142,11 @@ func (m *Manager) NewDBFromAddr(ctx context.Context, addr ma.Multiaddr, key thre
 		return nil, err
 	}
 
-	db, err := newDB(m.network, id, getDBOptions(id, m.newDBOptions, args.Collections...))
+	dbOpts, err := getDBOptions(id, m.newDBOptions, args.Collections...)
+	if err != nil {
+		return nil, err
+	}
+	db, err := newDB(m.network, id, dbOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -183,6 +195,9 @@ func (m *Manager) DeleteDB(ctx context.Context, id thread.ID, opts ...ManagedDBO
 	}
 
 	// Cleanup keys used by the db
+	if !id.Valid() {
+		return fmt.Errorf("invalid thread id")
+	}
 	pre := dsDBManagerBaseKey.ChildString(id.String())
 	q := query.Query{Prefix: pre.String(), KeysOnly: true}
 	results, err := m.newDBOptions.Datastore.Query(q)
@@ -218,7 +233,10 @@ func (m *Manager) Close() error {
 // getDBOptions copies the manager's base config,
 // wraps the datastore with an id prefix,
 // and merges specified collection configs with those from base
-func getDBOptions(id thread.ID, base *NewDBOptions, collections ...CollectionConfig) *NewDBOptions {
+func getDBOptions(id thread.ID, base *NewDBOptions, collections ...CollectionConfig) (*NewDBOptions, error) {
+	if !id.Valid() {
+		return nil, fmt.Errorf("invalid thread id")
+	}
 	return &NewDBOptions{
 		RepoPath: base.RepoPath,
 		Datastore: wrapTxnDatastore(base.Datastore, kt.PrefixTransform{
@@ -227,5 +245,5 @@ func getDBOptions(id thread.ID, base *NewDBOptions, collections ...CollectionCon
 		EventCodec:  base.EventCodec,
 		Debug:       base.Debug,
 		Collections: append(base.Collections, collections...),
-	}
+	}, nil
 }

--- a/examples/chat/main.go
+++ b/examples/chat/main.go
@@ -122,6 +122,10 @@ func main() {
 	}
 	go func() {
 		for rec := range sub {
+			if !rec.ThreadID().Valid() {
+				logError(fmt.Errorf("invalid thread id"))
+				continue
+			}
 			name, err := threadName(rec.ThreadID().String())
 			if err != nil {
 				logError(err)
@@ -324,6 +328,10 @@ func threadsCmd() (out string, err error) {
 			return
 		}
 		name := e.Key[strings.LastIndex(e.Key, "/")+1:]
+		if !id.Valid() {
+			err = fmt.Errorf("invalid thread id")
+			return
+		}
 		out += pink(name) + grey(" ("+id.String()+")")
 		if i != len(all)-1 {
 			out += "\n"
@@ -400,6 +408,10 @@ func addCmd(args []string) (out string, err error) {
 		return
 	}
 
+	if !id.Valid() {
+		err = fmt.Errorf("invalid thread id")
+		return
+	}
 	out = fmt.Sprintf("Added thread %s", id.String())
 	return
 }
@@ -445,6 +457,10 @@ func threadAddressCmd(id thread.ID) (out string, err error) {
 		lg = &thread.LogInfo{}
 	}
 
+	if !id.Valid() {
+		err = fmt.Errorf("invalid thread id")
+		return
+	}
 	ta, err := ma.NewMultiaddr("/" + thread.Name + "/" + id.String())
 	if err != nil {
 		return
@@ -549,6 +565,9 @@ func threadName(id string) (name string, err error) {
 		i, err := thread.Cast(e.Value)
 		if err != nil {
 			return "", err
+		}
+		if !i.Valid() {
+			return "", fmt.Errorf("invalid thread id")
 		}
 		if i.String() == id {
 			return e.Key[strings.LastIndex(e.Key, "/")+1:], nil

--- a/examples/chat/main.go
+++ b/examples/chat/main.go
@@ -122,8 +122,8 @@ func main() {
 	}
 	go func() {
 		for rec := range sub {
-			if !rec.ThreadID().Valid() {
-				logError(fmt.Errorf("invalid thread id"))
+			if err := rec.ThreadID().Validate(); err != nil {
+				logError(err)
 				continue
 			}
 			name, err := threadName(rec.ThreadID().String())
@@ -328,8 +328,7 @@ func threadsCmd() (out string, err error) {
 			return
 		}
 		name := e.Key[strings.LastIndex(e.Key, "/")+1:]
-		if !id.Valid() {
-			err = fmt.Errorf("invalid thread id")
+		if err = id.Validate(); err != nil {
 			return
 		}
 		out += pink(name) + grey(" ("+id.String()+")")
@@ -408,8 +407,7 @@ func addCmd(args []string) (out string, err error) {
 		return
 	}
 
-	if !id.Valid() {
-		err = fmt.Errorf("invalid thread id")
+	if err = id.Validate(); err != nil {
 		return
 	}
 	out = fmt.Sprintf("Added thread %s", id.String())
@@ -457,8 +455,7 @@ func threadAddressCmd(id thread.ID) (out string, err error) {
 		lg = &thread.LogInfo{}
 	}
 
-	if !id.Valid() {
-		err = fmt.Errorf("invalid thread id")
+	if err = id.Validate(); err != nil {
 		return
 	}
 	ta, err := ma.NewMultiaddr("/" + thread.Name + "/" + id.String())
@@ -566,8 +563,8 @@ func threadName(id string) (name string, err error) {
 		if err != nil {
 			return "", err
 		}
-		if !i.Valid() {
-			return "", fmt.Errorf("invalid thread id")
+		if err := i.Validate(); err != nil {
+			return "", err
 		}
 		if i.String() == id {
 			return e.Key[strings.LastIndex(e.Key, "/")+1:], nil

--- a/examples/e2e_counter/writer.go
+++ b/examples/e2e_counter/writer.go
@@ -80,6 +80,9 @@ func saveThreadMultiaddrForOtherPeer(n net.Net, threadID thread.ID) {
 
 	// Create listen addr
 	id, _ := multiaddr.NewComponent("p2p", n.Host().ID().String())
+	if !threadID.Valid() {
+		checkErr(fmt.Errorf("invalid thread id"))
+	}
 	threadComp, _ := multiaddr.NewComponent("thread", threadID.String())
 
 	listenAddr := n.Host().Addrs()[0].Encapsulate(id).Encapsulate(threadComp).String()

--- a/examples/e2e_counter/writer.go
+++ b/examples/e2e_counter/writer.go
@@ -80,9 +80,8 @@ func saveThreadMultiaddrForOtherPeer(n net.Net, threadID thread.ID) {
 
 	// Create listen addr
 	id, _ := multiaddr.NewComponent("p2p", n.Host().ID().String())
-	if !threadID.Valid() {
-		checkErr(fmt.Errorf("invalid thread id"))
-	}
+	err = threadID.Validate()
+	checkErr(err)
 	threadComp, _ := multiaddr.NewComponent("thread", threadID.String())
 
 	listenAddr := n.Host().Addrs()[0].Encapsulate(id).Encapsulate(threadComp).String()

--- a/net/api/client/client.go
+++ b/net/api/client/client.go
@@ -424,5 +424,5 @@ func threadRecordFromProto(reply *pb.NewRecordReply, key crypto.DecryptionKey) (
 	if err != nil {
 		return nil, err
 	}
-	return net.NewRecord(rec, threadID, logID), nil
+	return net.NewRecord(rec, threadID, logID)
 }

--- a/net/net.go
+++ b/net/net.go
@@ -276,8 +276,7 @@ func (n *net) AddThread(ctx context.Context, addr ma.Multiaddr, opts ...core.New
 		}
 	}
 
-	if !id.Valid() {
-		err = fmt.Errorf("invalid thread id")
+	if err = id.Validate(); err != nil {
 		return
 	}
 	threadComp, err := ma.NewComponent(thread.Name, id.String())
@@ -330,8 +329,7 @@ func (n *net) getThreadWithAddrs(id thread.ID) (info thread.Info, err error) {
 	if err != nil {
 		return
 	}
-	if !tinfo.ID.Valid() {
-		err = fmt.Errorf("invalid thread id")
+	if err = tinfo.ID.Validate(); err != nil {
 		return
 	}
 	threadID, err = ma.NewComponent("thread", tinfo.ID.String())

--- a/net/net.go
+++ b/net/net.go
@@ -276,6 +276,10 @@ func (n *net) AddThread(ctx context.Context, addr ma.Multiaddr, opts ...core.New
 		}
 	}
 
+	if !id.Valid() {
+		err = fmt.Errorf("invalid thread id")
+		return
+	}
 	threadComp, err := ma.NewComponent(thread.Name, id.String())
 	if err != nil {
 		return
@@ -324,6 +328,10 @@ func (n *net) getThreadWithAddrs(id thread.ID) (info thread.Info, err error) {
 	}
 	peerID, err = ma.NewComponent("p2p", n.host.ID().String())
 	if err != nil {
+		return
+	}
+	if !tinfo.ID.Valid() {
+		err = fmt.Errorf("invalid thread id")
 		return
 	}
 	threadID, err = ma.NewComponent("thread", tinfo.ID.String())

--- a/net/net.go
+++ b/net/net.go
@@ -191,6 +191,9 @@ func (n *net) GetToken(ctx context.Context, identity thread.Identity) (tok threa
 }
 
 func (n *net) CreateThread(_ context.Context, id thread.ID, opts ...core.NewThreadOption) (info thread.Info, err error) {
+	if err = id.Validate(); err != nil {
+		return
+	}
 	args := &core.NewThreadOptions{}
 	for _, opt := range opts {
 		opt(args)
@@ -255,6 +258,9 @@ func (n *net) AddThread(ctx context.Context, addr ma.Multiaddr, opts ...core.New
 	if err != nil {
 		return
 	}
+	if err = id.Validate(); err != nil {
+		return
+	}
 	if err = n.ensureUnique(id); err != nil {
 		return
 	}
@@ -276,9 +282,6 @@ func (n *net) AddThread(ctx context.Context, addr ma.Multiaddr, opts ...core.New
 		}
 	}
 
-	if err = id.Validate(); err != nil {
-		return
-	}
 	threadComp, err := ma.NewComponent(thread.Name, id.String())
 	if err != nil {
 		return
@@ -307,6 +310,9 @@ func (n *net) AddThread(ctx context.Context, addr ma.Multiaddr, opts ...core.New
 }
 
 func (n *net) GetThread(_ context.Context, id thread.ID, opts ...core.ThreadOption) (info thread.Info, err error) {
+	if err = id.Validate(); err != nil {
+		return
+	}
 	args := &core.ThreadOptions{}
 	for _, opt := range opts {
 		opt(args)
@@ -327,9 +333,6 @@ func (n *net) getThreadWithAddrs(id thread.ID) (info thread.Info, err error) {
 	}
 	peerID, err = ma.NewComponent("p2p", n.host.ID().String())
 	if err != nil {
-		return
-	}
-	if err = tinfo.ID.Validate(); err != nil {
 		return
 	}
 	threadID, err = ma.NewComponent("thread", tinfo.ID.String())
@@ -358,6 +361,9 @@ func (n *net) getThreadSemaphore(id thread.ID) chan struct{} {
 }
 
 func (n *net) PullThread(ctx context.Context, id thread.ID, opts ...core.ThreadOption) error {
+	if err := id.Validate(); err != nil {
+		return err
+	}
 	args := &core.ThreadOptions{}
 	for _, opt := range opts {
 		opt(args)
@@ -443,6 +449,9 @@ func (n *net) pullThreadUnsafe(ctx context.Context, id thread.ID) error {
 }
 
 func (n *net) DeleteThread(ctx context.Context, id thread.ID, opts ...core.ThreadOption) error {
+	if err := id.Validate(); err != nil {
+		return err
+	}
 	args := &core.ThreadOptions{}
 	for _, opt := range opts {
 		opt(args)
@@ -494,6 +503,9 @@ func (n *net) deleteThread(ctx context.Context, id thread.ID) error {
 }
 
 func (n *net) AddReplicator(ctx context.Context, id thread.ID, paddr ma.Multiaddr, opts ...core.ThreadOption) (pid peer.ID, err error) {
+	if err = id.Validate(); err != nil {
+		return
+	}
 	args := &core.ThreadOptions{}
 	for _, opt := range opts {
 		opt(args)
@@ -593,6 +605,9 @@ func getDialable(addr ma.Multiaddr) (ma.Multiaddr, error) {
 }
 
 func (n *net) CreateRecord(ctx context.Context, id thread.ID, body format.Node, opts ...core.ThreadOption) (r core.ThreadRecord, err error) {
+	if err = id.Validate(); err != nil {
+		return
+	}
 	args := &core.ThreadOptions{}
 	for _, opt := range opts {
 		opt(args)
@@ -616,7 +631,10 @@ func (n *net) CreateRecord(ctx context.Context, id thread.ID, body format.Node, 
 
 	log.Debugf("added record %s (thread=%s, log=%s)", rec.Cid(), id, lg.ID)
 
-	r = NewRecord(rec, id, lg.ID)
+	r, err = NewRecord(rec, id, lg.ID)
+	if err != nil {
+		return
+	}
 	if err = n.bus.SendWithTimeout(r, notifyTimeout); err != nil {
 		return
 	}
@@ -627,6 +645,9 @@ func (n *net) CreateRecord(ctx context.Context, id thread.ID, body format.Node, 
 }
 
 func (n *net) AddRecord(ctx context.Context, id thread.ID, lid peer.ID, rec core.Record, opts ...core.ThreadOption) error {
+	if err := id.Validate(); err != nil {
+		return err
+	}
 	args := &core.ThreadOptions{}
 	for _, opt := range opts {
 		opt(args)
@@ -661,6 +682,9 @@ func (n *net) AddRecord(ctx context.Context, id thread.ID, lid peer.ID, rec core
 }
 
 func (n *net) GetRecord(ctx context.Context, id thread.ID, rid cid.Cid, opts ...core.ThreadOption) (core.Record, error) {
+	if err := id.Validate(); err != nil {
+		return nil, err
+	}
 	args := &core.ThreadOptions{}
 	for _, opt := range opts {
 		opt(args)
@@ -689,8 +713,11 @@ type Record struct {
 }
 
 // NewRecord returns a record with the given values.
-func NewRecord(r core.Record, id thread.ID, lid peer.ID) core.ThreadRecord {
-	return &Record{Record: r, threadID: id, logID: lid}
+func NewRecord(r core.Record, id thread.ID, lid peer.ID) (core.ThreadRecord, error) {
+	if err := id.Validate(); err != nil {
+		return nil, err
+	}
+	return &Record{Record: r, threadID: id, logID: lid}, nil
 }
 
 func (r *Record) Value() core.Record {
@@ -716,6 +743,9 @@ func (n *net) Subscribe(ctx context.Context, opts ...core.SubOption) (<-chan cor
 
 	filter := make(map[thread.ID]struct{})
 	for _, id := range args.ThreadIDs {
+		if err := id.Validate(); err != nil {
+			return nil, err
+		}
 		if id.Defined() {
 			filter[id] = struct{}{}
 		}
@@ -755,6 +785,9 @@ func (n *net) subscribe(ctx context.Context, filter map[thread.ID]struct{}) (<-c
 }
 
 func (n *net) ConnectApp(a app.App, threadID thread.ID) (*app.Connector, error) {
+	if err := threadID.Validate(); err != nil {
+		return nil, err
+	}
 	info, err := n.getThreadWithAddrs(threadID)
 	if err != nil {
 		return nil, fmt.Errorf("error getting thread %s: %v", threadID, err)
@@ -766,6 +799,9 @@ func (n *net) ConnectApp(a app.App, threadID thread.ID) (*app.Connector, error) 
 
 // PutRecord adds an existing record. This method is thread-safe
 func (n *net) PutRecord(ctx context.Context, id thread.ID, lid peer.ID, rec core.Record) error {
+	if err := id.Validate(); err != nil {
+		return err
+	}
 	tsph := n.getThreadSemaphore(id)
 	tsph <- struct{}{}
 	defer func() { <-tsph }()
@@ -837,7 +873,11 @@ func (n *net) putRecord(ctx context.Context, id thread.ID, lid peer.ID, rec core
 		if err = n.store.SetHead(id, lg.ID, r.Cid()); err != nil {
 			return err
 		}
-		if err = n.bus.SendWithTimeout(NewRecord(r, id, lg.ID), notifyTimeout); err != nil {
+		record, err := NewRecord(r, id, lg.ID)
+		if err != nil {
+			return err
+		}
+		if err = n.bus.SendWithTimeout(record, notifyTimeout); err != nil {
 			return err
 		}
 	}

--- a/net/pubsub.go
+++ b/net/pubsub.go
@@ -53,8 +53,8 @@ func (s *PubSub) Add(id thread.ID) error {
 		return nil
 	}
 
-	if !id.Valid() {
-		return fmt.Errorf("invalid thread id")
+	if err := id.Validate(); err != nil {
+		return err
 	}
 	pt, err := s.ps.Join(id.String())
 	if err != nil {
@@ -90,8 +90,8 @@ func (s *PubSub) Remove(id thread.ID) error {
 	}
 	topic.s.Cancel()
 	topic.h.Cancel()
-	if !id.Valid() {
-		return fmt.Errorf("invalid thread id")
+	if err := id.Validate(); err != nil {
+		return err
 	}
 	if err := s.ps.UnregisterTopicValidator(id.String()); err != nil {
 		return err

--- a/net/pubsub.go
+++ b/net/pubsub.go
@@ -53,6 +53,9 @@ func (s *PubSub) Add(id thread.ID) error {
 		return nil
 	}
 
+	if !id.Valid() {
+		return fmt.Errorf("invalid thread id")
+	}
 	pt, err := s.ps.Join(id.String())
 	if err != nil {
 		return err
@@ -87,6 +90,9 @@ func (s *PubSub) Remove(id thread.ID) error {
 	}
 	topic.s.Cancel()
 	topic.h.Cancel()
+	if !id.Valid() {
+		return fmt.Errorf("invalid thread id")
+	}
 	if err := s.ps.UnregisterTopicValidator(id.String()); err != nil {
 		return err
 	}

--- a/threads/main.go
+++ b/threads/main.go
@@ -121,6 +121,10 @@ func executor(in string) {
 			fmt.Println("You must provide a db ID.")
 			return
 		}
+		if !currentDB.Valid() {
+			fmt.Printf("Invalid thread id\n")
+			return
+		}
 		if currentDB.String() == blocks[1] {
 			fmt.Printf("Already using %s\n", blocks[1])
 			return
@@ -137,6 +141,10 @@ func executor(in string) {
 		fmt.Println("Bye!")
 		os.Exit(0)
 	default:
+		if !currentDB.Valid() {
+			fmt.Printf("Invalid thread id\n")
+			return
+		}
 		if currentDB.String() == "" {
 			fmt.Println(noDBMessage)
 			return

--- a/threads/main.go
+++ b/threads/main.go
@@ -121,8 +121,8 @@ func executor(in string) {
 			fmt.Println("You must provide a db ID.")
 			return
 		}
-		if !currentDB.Valid() {
-			fmt.Printf("Invalid thread id\n")
+		if err := currentDB.Validate(); err != nil {
+			fmt.Printf("Invalid thread id: %v\n", err)
 			return
 		}
 		if currentDB.String() == blocks[1] {
@@ -141,8 +141,8 @@ func executor(in string) {
 		fmt.Println("Bye!")
 		os.Exit(0)
 	default:
-		if !currentDB.Valid() {
-			fmt.Printf("Invalid thread id\n")
+		if err := currentDB.Validate(); err != nil {
+			fmt.Printf("Invalid thread id: %v\n", err)
 			return
 		}
 		if currentDB.String() == "" {


### PR DESCRIPTION
Sorry @asutula, I didn't grasp that the problem was related to JSON Schemas. So, adding this PR to reduce work. Feel free to take it over. 

Some notes:
- There doesn't seem to be a way to reflect a private attribute. 
- +1 to your original solution.
- This branch has been `reset --hard` to when before you reverted the change, plus a small nits I added. I wasn't able to easily cherry-pick your `better error message` commit, so I made the change manually. 

So, the downside to this, and why I was resistant, is that not there's nothing stopping me from doing `myID := ID("foo")`, which is not a valid `ID`. Calling `String()` on `myID` would panic if we weren't hardcoding the response from `Version()`, which we should probably not be doing anymore since now it's possible to create a version other than `V1`. Maybe we can add a `Valid()` or similar method that could be called to ensure `String()` won't panic when you're unsure. 