### PR TITLE
Check for read key or public key when adding Threads

### DIFF
--- a/net/net.go
+++ b/net/net.go
@@ -271,13 +271,15 @@ func (n *net) AddThread(ctx context.Context, addr ma.Multiaddr, opts ...core.New
 	}); err != nil {
 		return
 	}
-	var linfo thread.LogInfo
-	linfo, err = createLog(n.host.ID(), args.LogKey)
-	if err != nil {
-		return
-	}
-	if err = n.store.AddLog(id, linfo); err != nil {
-		return
+	if args.ThreadKey.CanRead() || args.LogKey != nil {
+		var linfo thread.LogInfo
+		linfo, err = createLog(n.host.ID(), args.LogKey)
+		if err != nil {
+			return
+		}
+		if err = n.store.AddLog(id, linfo); err != nil {
+			return
+		}
 	}
 
 	threadComp, err := ma.NewComponent(thread.Name, id.String())

--- a/net/net.go
+++ b/net/net.go
@@ -271,15 +271,13 @@ func (n *net) AddThread(ctx context.Context, addr ma.Multiaddr, opts ...core.New
 	}); err != nil {
 		return
 	}
-	if args.ThreadKey.CanRead() {
-		var linfo thread.LogInfo
-		linfo, err = createLog(n.host.ID(), args.LogKey)
-		if err != nil {
-			return
-		}
-		if err = n.store.AddLog(id, linfo); err != nil {
-			return
-		}
+	var linfo thread.LogInfo
+	linfo, err = createLog(n.host.ID(), args.LogKey)
+	if err != nil {
+		return
+	}
+	if err = n.store.AddLog(id, linfo); err != nil {
+		return
 	}
 
 	threadComp, err := ma.NewComponent(thread.Name, id.String())


### PR DESCRIPTION
This is a teeny tiny PR to skip checking for a read key when AddThread is called to add a remote thread. This is a prelim PR to initiate a discussion, as this might not be the best approach.

Here is some context:

When calling `AddThread` from the `net` API, there is currently a check to see if the ThreadKey has Read access (https://github.com/textileio/go-threads/blob/master/net/net.go#L274). This seems like a reasonable check, however, this means no log is created. In settings where the net _client_ does have the Read key, but isn't sharing it with the net _service_ (which is the case with our JS client), this might not be ideal, because there is no log created to push even encrypted updates to. With `CreateThread` this is never an issue, because that check isn't performed, which makes sense because the client is _creating_ the thread, so it clearly have write permission, even if in practice, it hasn't sent over the key...

To add some details here, this issue is cropping because of how `CreateRecord` works via the JS network client. The reason this is an issue is because, to avoid sending over the keys to the remote host, under the hood the JS client actually calls `AddRecord` instead of `CreateRecord`. Now, since `AddRecord` doesn't ever call `getOrCreateOwnLog` (which makes sense), we get to a point where we don't have a log to write to... and the remote net layer throws an error.

This PR is one solution to this problem, where the log _is_ created, regardless of if the remote host has read permission or not. The nice thing here is that, even though the log has been created, it still doesn't have the required keys to _do_ anything with the log data, so privacy is preserved.