### PR TITLE
Flag locally created logs as direct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,10 @@ api/pb/dart/lib
 
 # vscode config folder
 .vscode/
+.idea/
 
 **/node_modules
 tags
+
+# Misc
+**.DS_Store

--- a/core/logstore/logstore.go
+++ b/core/logstore/logstore.go
@@ -22,6 +22,9 @@ var ErrThreadNotFound = fmt.Errorf("thread not found")
 // ErrLogNotFound indicates a requested log was not found.
 var ErrLogNotFound = fmt.Errorf("log not found")
 
+// ErrLogExists indicates a requested log already exists.
+var ErrLogExists = fmt.Errorf("log already exists")
+
 // Logstore stores log keys, addresses, heads and thread meta data.
 type Logstore interface {
 	Close() error
@@ -49,8 +52,8 @@ type Logstore interface {
 	// GetLog returns info about a log.
 	GetLog(thread.ID, peer.ID) (thread.LogInfo, error)
 
-	// GetOwnLogs returns info about locally managed logs.
-	GetOwnLogs(thread.ID) ([]thread.LogInfo, error)
+	// GetManagedLogs returns info about locally managed logs.
+	GetManagedLogs(thread.ID) ([]thread.LogInfo, error)
 
 	// DeleteLog deletes a log.
 	DeleteLog(thread.ID, peer.ID) error

--- a/core/logstore/logstore.go
+++ b/core/logstore/logstore.go
@@ -49,6 +49,9 @@ type Logstore interface {
 	// GetLog returns info about a log.
 	GetLog(thread.ID, peer.ID) (thread.LogInfo, error)
 
+	// GetOwnLogs returns info about locally managed logs.
+	GetOwnLogs(thread.ID) ([]thread.LogInfo, error)
+
 	// DeleteLog deletes a log.
 	DeleteLog(thread.ID, peer.ID) error
 }
@@ -61,11 +64,17 @@ type ThreadMetadata interface {
 	// PutInt64 stores an int value under key.
 	PutInt64(t thread.ID, key string, val int64) error
 
-	// GetString retrieves an int value under key.
+	// GetString retrieves a string value under key.
 	GetString(t thread.ID, key string) (*string, error)
 
 	// PutString stores a string value under key.
 	PutString(t thread.ID, key string, val string) error
+
+	// GetBool retrieves a boolean value under key.
+	GetBool(t thread.ID, key string) (*bool, error)
+
+	// PutBool stores a boolean value under key.
+	PutBool(t thread.ID, key string, val bool) error
 
 	// GetBytes retrieves a byte value under key.
 	GetBytes(t thread.ID, key string) (*[]byte, error)

--- a/core/thread/id.go
+++ b/core/thread/id.go
@@ -366,10 +366,16 @@ func (i Info) GetOwnLog() *LogInfo {
 
 // LogInfo holds log keys, addresses, and heads.
 type LogInfo struct {
-	ID      peer.ID
-	PubKey  crypto.PubKey
+	// ID is the log's identifier.
+	ID peer.ID
+	// PubKey is the log's public key.
+	PubKey crypto.PubKey
+	// PrivKey is the log's private key.
 	PrivKey crypto.PrivKey
-	Addrs   []ma.Multiaddr
-	Head    cid.Cid
-	Direct  bool // Whether log is 'directly' managed (owned). Indirect logs are 'peer' logs.
+	// Addrs are the addresses associated with the given log.
+	Addrs []ma.Multiaddr
+	// Head is the log's current head.
+	Head cid.Cid
+	// Managed logs are any logs directly added/created by the host, and/or logs for which we have the private key
+	Managed bool
 }

--- a/core/thread/id.go
+++ b/core/thread/id.go
@@ -110,7 +110,7 @@ func Decode(v string) (ID, error) {
 	return Cast(data)
 }
 
-// Extract the encoding from an ID. If Decode on the same string did
+// ExtractEncoding from an ID. If Decode on the same string did
 // not return an error neither will this function.
 func ExtractEncoding(v string) (mbase.Encoding, error) {
 	if len(v) < 2 {
@@ -171,6 +171,7 @@ func uvError(read int) error {
 	}
 }
 
+// Validate the ID.
 func (i ID) Validate() error {
 	data := i.Bytes()
 	return validateIDData(data)
@@ -269,7 +270,7 @@ func (i ID) String() string {
 	}
 }
 
-// String returns the string representation of an ID
+// StringOfBase returns the string representation of an ID
 // encoded is selected base.
 func (i ID) StringOfBase(base mbase.Encoding) (string, error) {
 	if err := i.Validate(); err != nil {
@@ -353,6 +354,7 @@ type Info struct {
 }
 
 // GetOwnLog returns the first log found with a private key.
+// This is a strict owership check, vs returning all directly 'managed' logs.
 func (i Info) GetOwnLog() *LogInfo {
 	for _, lg := range i.Logs {
 		if lg.PrivKey != nil {
@@ -369,4 +371,5 @@ type LogInfo struct {
 	PrivKey crypto.PrivKey
 	Addrs   []ma.Multiaddr
 	Head    cid.Cid
+	Direct  bool // Whether log is 'directly' managed (owned). Indirect logs are 'peer' logs.
 }

--- a/db/db.go
+++ b/db/db.go
@@ -87,7 +87,7 @@ func NewDB(ctx context.Context, network app.Net, id thread.ID, opts ...NewOption
 		opt(args)
 	}
 
-	if _, err := network.CreateThread(ctx, id, net.WithNewThreadToken(args.Token)); err != nil {
+	if _, err := network.CreateThread(ctx, id, net.WithNewThreadToken(args.Token), net.WithThreadKey(args.ThreadKey)); err != nil {
 		if !errors.Is(err, lstore.ErrThreadExists) {
 			return nil, err
 		}

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -108,6 +108,9 @@ func TestWithNewName(t *testing.T) {
 		t.Fatalf("expected name %s, got %s", name, d.name)
 	}
 
+	_, key, err := d.GetDBInfo()
+	checkErr(t, err)
+
 	// Re-do again to re-use key. If something wasn't closed correctly, would fail
 	checkErr(t, n.Close())
 	checkErr(t, d.Close())
@@ -117,7 +120,7 @@ func TestWithNewName(t *testing.T) {
 	checkErr(t, err)
 	defer n.Close()
 	defer d.Close()
-	d, err = NewDB(context.Background(), n, id, WithNewRepoPath(tmpDir))
+	d, err = NewDB(context.Background(), n, id, WithNewRepoPath(tmpDir), WithNewThreadKey(key))
 	checkErr(t, err)
 	if d.name != name {
 		t.Fatalf("expected name %s, got %s", name, d.name)
@@ -150,6 +153,9 @@ func TestWithNewEventCodec(t *testing.T) {
 		t.Fatalf("custom event codec wasn't called")
 	}
 
+	_, key, err := d.GetDBInfo()
+	checkErr(t, err)
+
 	// Re-do again to re-use key. If something wasn't closed correctly, would fail
 	checkErr(t, n.Close())
 	checkErr(t, d.Close())
@@ -158,7 +164,7 @@ func TestWithNewEventCodec(t *testing.T) {
 	n, err = common.DefaultNetwork(tmpDir, common.WithNetDebug(true), common.WithNetHostAddr(util.FreeLocalAddr()))
 	checkErr(t, err)
 	defer n.Close()
-	d, err = NewDB(context.Background(), n, id, WithNewRepoPath(tmpDir), WithNewEventCodec(ec))
+	d, err = NewDB(context.Background(), n, id, WithNewRepoPath(tmpDir), WithNewEventCodec(ec), WithNewThreadKey(key))
 	checkErr(t, err)
 	checkErr(t, d.Close())
 }

--- a/db/options.go
+++ b/db/options.go
@@ -42,6 +42,7 @@ type NewOptions struct {
 	EventCodec  core.EventCodec
 	LowMem      bool
 	Debug       bool
+	ThreadKey   thread.Key
 }
 
 // NewOption specifies a new db option.
@@ -65,6 +66,13 @@ func WithNewRepoPath(path string) NewOption {
 func WithNewToken(t thread.Token) NewOption {
 	return func(o *NewOptions) {
 		o.Token = t
+	}
+}
+
+// WithNewThreadKey provides control over thread keys to use with a db.
+func WithNewThreadKey(key thread.Key) NewOption {
+	return func(o *NewOptions) {
+		o.ThreadKey = key
 	}
 }
 

--- a/logstore/lstoreds/metadata.go
+++ b/logstore/lstoreds/metadata.go
@@ -60,6 +60,22 @@ func (m *dsThreadMetadata) PutString(t thread.ID, key string, val string) error 
 	return m.setValue(t, key, val)
 }
 
+func (m *dsThreadMetadata) GetBool(t thread.ID, key string) (*bool, error) {
+	var val bool
+	err := m.getValue(t, key, &val)
+	if err == ds.ErrNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &val, nil
+}
+
+func (m *dsThreadMetadata) PutBool(t thread.ID, key string, val bool) error {
+	return m.setValue(t, key, val)
+}
+
 func (m *dsThreadMetadata) GetBytes(t thread.ID, key string) (*[]byte, error) {
 	var val []byte
 	err := m.getValue(t, key, &val)

--- a/logstore/lstoremem/metadata.go
+++ b/logstore/lstoremem/metadata.go
@@ -57,6 +57,19 @@ func (m *memoryThreadMetadata) GetString(t thread.ID, key string) (*string, erro
 	return &val, nil
 }
 
+func (m *memoryThreadMetadata) PutBool(t thread.ID, key string, val bool) error {
+	m.putValue(t, key, val)
+	return nil
+}
+
+func (m *memoryThreadMetadata) GetBool(t thread.ID, key string) (*bool, error) {
+	val, ok := m.getValue(t, key).(bool)
+	if !ok {
+		return nil, nil
+	}
+	return &val, nil
+}
+
 func (m *memoryThreadMetadata) PutBytes(t thread.ID, key string, val []byte) error {
 	b := make([]byte, len(val))
 	copy(b, val)

--- a/net/api/pb/threadsnet.proto
+++ b/net/api/pb/threadsnet.proto
@@ -49,6 +49,7 @@ message LogInfo {
     bytes privKey = 3;
     repeated bytes addrs = 4;
     bytes head = 5;
+    bool direct = 6;
 }
 
 message AddThreadRequest {

--- a/net/api/pb/threadsnet.proto
+++ b/net/api/pb/threadsnet.proto
@@ -49,7 +49,6 @@ message LogInfo {
     bytes privKey = 3;
     repeated bytes addrs = 4;
     bytes head = 5;
-    bool direct = 6;
 }
 
 message AddThreadRequest {

--- a/net/net.go
+++ b/net/net.go
@@ -264,6 +264,9 @@ func (n *net) ensureUnique(id thread.ID, key crypto.Key) error {
 		return err
 	}
 	_, err = n.store.GetLog(id, logID)
+	if err == nil {
+		return lstore.ErrLogExists
+	}
 	if !errors.Is(err, lstore.ErrLogNotFound) {
 		return err
 	}

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -174,6 +174,82 @@ func TestNet_AddThread(t *testing.T) {
 	}
 }
 
+func TestNet_CreateThreadManaged(t *testing.T) {
+	t.Parallel()
+	n := makeNetwork(t)
+	defer n.Close()
+
+	ctx := context.Background()
+	info, err := n.CreateThread(ctx, thread.NewIDV1(thread.Raw, 32))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sk, pk, err := crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Should fail if trying to re-create locally 'owned' thread
+	_, err = n.CreateThread(ctx, info.ID, core.WithLogKey(sk), core.WithThreadKey(info.Key))
+	if err == nil {
+		t.Fatalf("expected creating thread with second private key to fail")
+	}
+	// Should fail if trying to re-create thread with wrong read/service keys
+	_, err = n.CreateThread(ctx, info.ID, core.WithLogKey(pk))
+	if err == nil {
+		t.Fatalf("expected to fail when using wrong thread key(s)")
+	}
+	// Should work if only going to 'manage' re-created thread/log
+	_, err = n.CreateThread(ctx, info.ID, core.WithLogKey(pk), core.WithThreadKey(info.Key))
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNet_AddThreadManaged(t *testing.T) {
+	t.Parallel()
+	n1 := makeNetwork(t)
+	defer n1.Close()
+	n2 := makeNetwork(t)
+	defer n2.Close()
+
+	n1.Host().Peerstore().AddAddrs(n2.Host().ID(), n2.Host().Addrs(), peerstore.PermanentAddrTTL)
+	n2.Host().Peerstore().AddAddrs(n1.Host().ID(), n1.Host().Addrs(), peerstore.PermanentAddrTTL)
+
+	ctx := context.Background()
+	info, err := n1.CreateThread(ctx, thread.NewIDV1(thread.Raw, 32))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	addr, err := ma.NewMultiaddr("/p2p/" + n1.Host().ID().String() + "/thread/" + info.ID.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sk, pk, err := crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = n2.AddThread(ctx, addr, core.WithThreadKey(info.Key))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Should fail if trying to re-create locally 'owned' thread
+	_, err = n2.AddThread(ctx, addr, core.WithLogKey(sk), core.WithThreadKey(info.Key))
+	if err == nil {
+		t.Fatalf("expected creating thread with second private key to fail")
+	}
+	// Should fail if trying to re-create thread with wrong/missing read/service keys
+	_, err = n2.AddThread(ctx, addr, core.WithLogKey(pk))
+	if err == nil {
+		t.Fatalf("expected to fail when using wrong thread key(s)")
+	}
+	// Should work if only going to 'manage' re-created thread/log
+	_, err = n2.AddThread(ctx, addr, core.WithLogKey(pk), core.WithThreadKey(info.Key))
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestNet_AddReplicator(t *testing.T) {
 	t.Parallel()
 	n1 := makeNetwork(t)
@@ -194,6 +270,59 @@ func TestNet_AddReplicator(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := n1.CreateRecord(ctx, info.ID, body); err != nil {
+		t.Fatal(err)
+	}
+
+	addr, err := ma.NewMultiaddr("/p2p/" + n2.Host().ID().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = n1.AddReplicator(ctx, info.ID, addr); err != nil {
+		t.Fatal(err)
+	}
+
+	info2, err := n1.GetThread(context.Background(), info.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(info2.Logs) != 1 {
+		t.Fatalf("expected 1 log got %d", len(info2.Logs))
+	}
+	if len(info2.Logs[0].Addrs) != 2 {
+		t.Fatalf("expected 2 addresses got %d", len(info2.Logs[0].Addrs))
+	}
+
+	info3, err := n2.GetThread(context.Background(), info.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(info3.Logs) != 1 {
+		t.Fatalf("expected 1 log got %d", len(info2.Logs))
+	}
+	if len(info3.Logs[0].Addrs) != 2 {
+		t.Fatalf("expected 2 addresses got %d", len(info3.Logs[0].Addrs))
+	}
+}
+
+func TestNet_AddReplicatorManaged(t *testing.T) {
+	t.Parallel()
+	n1 := makeNetwork(t)
+	defer n1.Close()
+	n2 := makeNetwork(t)
+	defer n2.Close()
+
+	n1.Host().Peerstore().AddAddrs(n2.Host().ID(), n2.Host().Addrs(), peerstore.PermanentAddrTTL)
+	n2.Host().Peerstore().AddAddrs(n1.Host().ID(), n1.Host().Addrs(), peerstore.PermanentAddrTTL)
+
+	// Create managed thread
+	tid := thread.NewIDV1(thread.Raw, 32)
+	ctx := context.Background()
+	_, pk, err := crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := n1.CreateThread(ctx, tid, core.WithLogKey(pk))
+	if err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Fixes #373, and a better alternative to #372.

The approach here is to simply take advantage of the existing metadata store on the logstore to set a flag as to whether a given log is "managed?" by the local peer. Directly "managed" logs are those logs created or directly added by the local peer. Otherwise, unmanaged logs are those from other peers in a given thread. Related, "owned" logs are those logs for which the peer has the private key. There can only be _one_ "owned" log, versus potentially many "managed" logs.

This should support multiple use cases:
* The local peer is the client peer. One "owned" log is used to interact with a given thread (single-tenant, single-writer setup)
* The local peer is (also) a relay peer. Maybe multiple "managed" logs on behalf of other clients, and zero or one "owned" log to also participate in the thread on its own (multi-tenant, multi-writer setup)
* The local peer is (also) a proxy-writer. Maybe multiple "managed" logs on behalf of other clients, and one "owned" log that is written to on behalf of other 'agents' (multi-tenant, single-writer setup)