### PR TITLE
Let peers add threads from self + replicate

### DIFF
--- a/net/net.go
+++ b/net/net.go
@@ -304,7 +304,7 @@ func (n *net) AddThread(ctx context.Context, addr ma.Multiaddr, opts ...core.New
 	}
 
 	// Check if we're trying to dial ourselves (regardless of addr)
-	addFromSelf := addri.ID.Pretty() == n.host.ID().Pretty()
+	addFromSelf := addri.ID == n.host.ID()
 	if addFromSelf {
 		// Error if we don't have the thread locally
 		if _, err = n.store.GetThread(id); errors.Is(err, lstore.ErrThreadNotFound) {
@@ -593,7 +593,7 @@ func (n *net) AddReplicator(ctx context.Context, id thread.ID, paddr ma.Multiadd
 	}
 
 	// Check if we're dialing ourselves (regardless of addr)
-	if pid.Pretty() != n.host.ID().Pretty() {
+	if pid != n.host.ID() {
 		// If not, update peerstore address
 		var dialable ma.Multiaddr
 		dialable, err = getDialable(paddr)
@@ -608,7 +608,7 @@ func (n *net) AddReplicator(ctx context.Context, id thread.ID, paddr ma.Multiadd
 			if err = n.server.pushLog(ctx, info.ID, l, pid, info.Key.Service(), nil); err != nil {
 				for _, lg := range managedLogs {
 					// Rollback this log only and then bail
-					if lg.ID.Pretty() == l.ID.Pretty() {
+					if lg.ID == l.ID {
 						if err := n.store.SetAddrs(info.ID, lg.ID, lg.Addrs, pstore.PermanentAddrTTL); err != nil {
 							log.Errorf("error rolling back log address change: %s", err)
 						}

--- a/net/net.go
+++ b/net/net.go
@@ -303,12 +303,12 @@ func (n *net) AddThread(ctx context.Context, addr ma.Multiaddr, opts ...core.New
 		return
 	}
 
-	// Check if we're dialing ourselves (regardless of addr)
+	// Check if we're trying to dial ourselves (regardless of addr)
 	addFromSelf := addri.ID.Pretty() == n.host.ID().Pretty()
 	if addFromSelf {
 		// Error if we don't have the thread locally
 		if _, err = n.store.GetThread(id); errors.Is(err, lstore.ErrThreadNotFound) {
-			err = fmt.Errorf("cannot retrive thread from self: %s", err)
+			err = fmt.Errorf("cannot retrieve thread from self: %s", err)
 			return
 		}
 	}

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -248,6 +248,15 @@ func TestNet_AddThreadManaged(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Should work if trying to add new managed log to 'self' (note we're using n1 here)
+	sk, pk, err = crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = n1.AddThread(ctx, addr, core.WithLogKey(pk), core.WithThreadKey(info.Key))
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestNet_AddReplicator(t *testing.T) {
@@ -354,6 +363,11 @@ func TestNet_AddReplicatorManaged(t *testing.T) {
 	}
 	if len(info3.Logs[0].Addrs) != 2 {
 		t.Fatalf("expected 2 addresses got %d", len(info3.Logs[0].Addrs))
+	}
+
+	// Should be able to add self as replicator
+	if _, err = n2.AddReplicator(ctx, info.ID, addr); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
Avoids extraneous dials when the data can assume to be already available locally (self dials). This is useful/required for multi-tenant setups where a single peer may be managing multiple threads/logs on behalf of other (remote) peers. For instance, we don't want clients to 'care' if their remote host is already be replicating a thread they are involved in.

Ideally, there would be some logic in here to catch things like this (or other combinations of local vs remote addrs):

```
import manet "github.com/multiformats/go-multiaddr-net"
...
// Early out if we aren't going to be able to dial this peer
if !manet.IsPublicAddr(addr) {
	err = fmt.Errorf("addr must be publicly routable address")
	return
}
```

But I don't think we can assume, based on address alone, that we can filter something out. We might be,
* A local peer dialing another peer on the same machine
* A local peer dialing another peer on another machine on the same local network
* A local peer dialing another peer on another machine on the internet
* A client peer controlling a remote peer to do any of the above

So I'm going to leave most of the 'filtering' logic to clients. For now, the Go client will _not_ do any filtering, because likely it is operating via a localhost, but the Javascript clients should filter out local host addrs by default.