### PR TITLE
Catch nil collection on reduce

### DIFF
--- a/db/collection.go
+++ b/db/collection.go
@@ -56,9 +56,8 @@ func newCollection(name string, schema *jsonschema.Schema, d *DB) (*Collection, 
 	if err != nil {
 		if errors.Is(err, ErrInvalidCollectionSchemaPath) {
 			return nil, ErrInvalidCollectionSchema
-		} else {
-			return nil, err
 		}
+		return nil, err
 	}
 	if idType.Type != "string" {
 		return nil, ErrInvalidCollectionSchema
@@ -105,7 +104,7 @@ func (c *Collection) FindByID(id core.InstanceID, opts ...TxnOption) (instance [
 
 // Create creates an instance in the collection.
 func (c *Collection) Create(v []byte, opts ...TxnOption) (id core.InstanceID, err error) {
-	_ = c.WriteTxn(func(txn *Txn) error {
+	err = c.WriteTxn(func(txn *Txn) error {
 		var ids []core.InstanceID
 		ids, err = txn.Create(v)
 		if err != nil {
@@ -121,7 +120,7 @@ func (c *Collection) Create(v []byte, opts ...TxnOption) (id core.InstanceID, er
 
 // CreateMany creates multiple instances in the collection.
 func (c *Collection) CreateMany(vs [][]byte, opts ...TxnOption) (ids []core.InstanceID, err error) {
-	_ = c.WriteTxn(func(txn *Txn) error {
+	err = c.WriteTxn(func(txn *Txn) error {
 		ids, err = txn.Create(vs...)
 		return err
 	}, opts...)
@@ -136,7 +135,7 @@ func (c *Collection) Delete(id core.InstanceID, opts ...TxnOption) error {
 	}, opts...)
 }
 
-// Delete deletes multiple instances by ID. It doesn't
+// DeleteMany deletes multiple instances by ID. It doesn't
 // fail if one of the IDs don't exist.
 func (c *Collection) DeleteMany(ids []core.InstanceID, opts ...TxnOption) error {
 	return c.WriteTxn(func(txn *Txn) error {

--- a/db/db.go
+++ b/db/db.go
@@ -445,6 +445,9 @@ func (d *DB) Reduce(events []core.Event) error {
 func defaultIndexFunc(d *DB) func(collection string, key ds.Key, oldData, newData []byte, txn ds.Txn) error {
 	return func(collection string, key ds.Key, oldData, newData []byte, txn ds.Txn) error {
 		c := d.GetCollection(collection)
+		if c == nil {
+			return fmt.Errorf("collection (%s) not found", collection)
+		}
 		if err := c.indexDelete(txn, key, oldData); err != nil {
 			return err
 		}


### PR DESCRIPTION
If a peer calls `addDBFromAddr` _without_ specifying the `Collections`, it can end up in a state where it then received some remote record(s), and since it is not aware of the Collection, it panics upon trying to use the collection in its reducer function (because the collection doesn't exist). This PR catches the nil reference, and bubbles the error back up to the Reduce method, which will now safely throw the error. This also adds a test to check for this possible state. In performing said test, an additional bug was discovered, in that some write transactions on the database were never returning errors from the dispatcher, so this PR also includes that small fix.

Fixes #379 
Fixes #381