### PR TITLE
Don't panic on empty schemas when looking for _id

### DIFF
--- a/db/collection.go
+++ b/db/collection.go
@@ -245,7 +245,7 @@ func (t *Txn) Create(new ...[]byte) ([]core.InstanceID, error) {
 	return results, nil
 }
 
-// Save saves an instance changes to be commited when the current transaction commits.
+// Save saves an instance changes to be committed when the current transaction commits.
 func (t *Txn) Save(updated ...[]byte) error {
 	for i := range updated {
 		if t.readonly {
@@ -393,9 +393,6 @@ func getSchemaTypeAtPath(schema *jsonschema.Schema, pth string) (*jsonschema.Typ
 		if err != nil {
 			return nil, err
 		}
-		if props == nil {
-			return nil, ErrInvalidCollectionSchemaPath
-		}
 		jt = props[n]
 		if jt == nil {
 			return nil, ErrInvalidCollectionSchemaPath
@@ -405,10 +402,10 @@ func getSchemaTypeAtPath(schema *jsonschema.Schema, pth string) (*jsonschema.Typ
 }
 
 // getSchemaTypeProperties extracts a map of schema properties from a given input schema.
-// If there are no available properties, it will return an empty (nil) map
+// If there are no available properties, it will return an empty map
 func getSchemaTypeProperties(jt *jsonschema.Type, defs jsonschema.Definitions) (map[string]*jsonschema.Type, error) {
 	if jt == nil {
-		return nil, nil
+		return make(map[string]*jsonschema.Type), nil
 	}
 	properties := jt.Properties
 	if jt.Ref != "" {

--- a/db/collection.go
+++ b/db/collection.go
@@ -393,6 +393,9 @@ func getSchemaTypeAtPath(schema *jsonschema.Schema, pth string) (*jsonschema.Typ
 		if err != nil {
 			return nil, err
 		}
+		if props == nil {
+			return nil, ErrInvalidCollectionSchemaPath
+		}
 		jt = props[n]
 		if jt == nil {
 			return nil, ErrInvalidCollectionSchemaPath
@@ -401,7 +404,12 @@ func getSchemaTypeAtPath(schema *jsonschema.Schema, pth string) (*jsonschema.Typ
 	return jt, nil
 }
 
+// getSchemaTypeProperties extracts a map of schema properties from a given input schema.
+// If there are no available properties, it will return an empty (nil) map
 func getSchemaTypeProperties(jt *jsonschema.Type, defs jsonschema.Definitions) (map[string]*jsonschema.Type, error) {
+	if jt == nil {
+		return nil, nil
+	}
 	properties := jt.Properties
 	if jt.Ref != "" {
 		parts := strings.Split(jt.Ref, "/")

--- a/db/collection_test.go
+++ b/db/collection_test.go
@@ -349,6 +349,21 @@ func TestAddIndex(t *testing.T) {
 	})
 }
 
+func TestEmptySchema(t *testing.T) {
+	t.Parallel()
+	db, clean := createTestDB(t)
+	defer clean()
+	// Note the empty schema {}, this is a catch all schema
+	schema := util.SchemaFromSchemaString("{}")
+	_, err := db.NewCollection(CollectionConfig{
+		Name:   "Person",
+		Schema: schema,
+	})
+	if err != ErrInvalidCollectionSchema {
+		t.Fatalf("expected to throw ErrInvalidCollectionSchema error")
+	}
+}
+
 func TestGetIndexes(t *testing.T) {
 	t.Parallel()
 	db, clean := createTestDB(t)


### PR DESCRIPTION
Also adds tests for this edge case to prevent regressions.

Fixes #369 

Note that this still will cause an error if the schema _doesn't_ have an `_id` field. This makes things safer on the Go side. Calling clients should ensure on the client side that this is the case _before_ calling out to the remote Go peer.