### PR TITLE
manager: catch missing dbs

### DIFF
--- a/api/service.go
+++ b/api/service.go
@@ -284,8 +284,8 @@ func (s *Service) DeleteDB(ctx context.Context, req *pb.DeleteDBRequest) (*pb.De
 	}
 
 	if err = s.manager.DeleteDB(ctx, id, db.WithManagedToken(token)); err != nil {
-		if errors.Is(err, lstore.ErrThreadNotFound) {
-			return nil, status.Error(codes.NotFound, db.ErrDBNotFound.Error())
+		if errors.Is(err, lstore.ErrThreadNotFound) || errors.Is(err, db.ErrDBNotFound) {
+			return nil, status.Error(codes.NotFound, err.Error())
 		} else {
 			return nil, err
 		}
@@ -839,8 +839,8 @@ func (s *Service) processFindRequest(req *pb.FindRequest, token thread.Token, fi
 func (s *Service) getDB(ctx context.Context, id thread.ID, token thread.Token) (*db.DB, error) {
 	d, err := s.manager.GetDB(ctx, id, db.WithManagedToken(token))
 	if err != nil {
-		if errors.Is(err, lstore.ErrThreadNotFound) {
-			return nil, status.Error(codes.NotFound, db.ErrDBNotFound.Error())
+		if errors.Is(err, lstore.ErrThreadNotFound) || errors.Is(err, db.ErrDBNotFound) {
+			return nil, status.Error(codes.NotFound, err.Error())
 		} else {
 			return nil, err
 		}

--- a/db/manager.go
+++ b/db/manager.go
@@ -198,7 +198,11 @@ func (m *Manager) GetDB(ctx context.Context, id thread.ID, opts ...ManagedOption
 	if _, err := m.network.GetThread(ctx, id, net.WithThreadToken(args.Token)); err != nil {
 		return nil, err
 	}
-	return m.dbs[id], nil
+	db, ok := m.dbs[id]
+	if !ok {
+		return nil, ErrDBNotFound
+	}
+	return db, nil
 }
 
 // DeleteDB deletes a db by id.
@@ -210,9 +214,9 @@ func (m *Manager) DeleteDB(ctx context.Context, id thread.ID, opts ...ManagedOpt
 	if _, err := m.network.GetThread(ctx, id, net.WithThreadToken(args.Token)); err != nil {
 		return err
 	}
-	db := m.dbs[id]
-	if db == nil {
-		return nil
+	db, ok := m.dbs[id]
+	if !ok {
+		return ErrDBNotFound
 	}
 
 	if err := db.Close(); err != nil {

--- a/db/manager_test.go
+++ b/db/manager_test.go
@@ -122,6 +122,11 @@ func TestManager_GetDB(t *testing.T) {
 	}()
 
 	id := thread.NewIDV1(thread.Raw, 32)
+	_, err = man.GetDB(ctx, id)
+	if !errors.Is(err, lstore.ErrThreadNotFound) {
+		t.Fatal("should be not found error")
+	}
+
 	_, err = man.NewDB(ctx, id)
 	checkErr(t, err)
 	db, err := man.GetDB(ctx, id)


### PR DESCRIPTION
This fixes a panic when you try to get a database that is based on a thread which _does_ exist, but _is not_ a database thread. 