### PR TITLE
Unprotect net.AddRecord

### DIFF
--- a/core/net/net.go
+++ b/core/net/net.go
@@ -73,7 +73,7 @@ type API interface {
 
 // Token is used to restrict network APIs to a single app.App.
 // In other words, a net token protects against writes and deletes
-// external to an app.
+// which are external to an app.
 type Token []byte
 
 func (t Token) Equal(b Token) bool {

--- a/core/net/options.go
+++ b/core/net/options.go
@@ -58,7 +58,7 @@ func WithThreadToken(t thread.Token) ThreadOption {
 // WithAPIToken provides additional authorization for interacting
 // with a thread as an application.
 // For example, this is used by a db.DB to ensure that only it can
-// create/add records or delete the underlying thread.
+// create records or delete the underlying thread.
 func WithAPIToken(t Token) ThreadOption {
 	return func(args *ThreadOptions) {
 		args.APIToken = t

--- a/net/net.go
+++ b/net/net.go
@@ -721,9 +721,6 @@ func (n *net) AddRecord(ctx context.Context, id thread.ID, lid peer.ID, rec core
 	if _, err := args.Token.Validate(n.getPrivKey()); err != nil {
 		return err
 	}
-	if !n.validateAPIToken(id, args.APIToken) {
-		return fmt.Errorf("cannot add record: %w", app.ErrThreadInUse)
-	}
 
 	logpk, err := n.store.PubKey(id, lid)
 	if err != nil {
@@ -872,6 +869,9 @@ func (n *net) ConnectApp(a app.App, id thread.ID) (*app.Connector, error) {
 	return con, nil
 }
 
+// validateAPIToken checks if the thread is backing an app,
+// and if so, returns whether or not the token matches the app
+// connector's token.
 func (n *net) validateAPIToken(id thread.ID, token core.Token) bool {
 	t, ok := n.apps[id]
 	if !ok {


### PR DESCRIPTION
Oops, of course `AddRecord` can't be protected like this! 