### PR TITLE
db: fix listeners double close

### DIFF
--- a/db/listeners.go
+++ b/db/listeners.go
@@ -128,7 +128,7 @@ func (scn *stateChangedNotifee) close() {
 	scn.lock.Lock()
 	defer scn.lock.Unlock()
 	for i := range scn.listeners {
-		close(scn.listeners[i].c)
+		scn.listeners[i].Close()
 	}
 }
 


### PR DESCRIPTION
Closes #401 

All listener channels are directly closed on service shutdown, but when their contexts are canceled, they are closed again via `Close`, which indirectly checks if `c` has been closed already.