### PR TITLE
Nits for textile mailboxes

### DIFF
--- a/api/service.go
+++ b/api/service.go
@@ -108,6 +108,10 @@ func (i *remoteIdentity) GetPublic() thread.PubKey {
 	return i.pk
 }
 
+func (i *remoteIdentity) Decrypt(context.Context, []byte) ([]byte, error) {
+	return nil, nil // no-op
+}
+
 func (s *Service) GetToken(server pb.API_GetTokenServer) error {
 	log.Debugf("received get token request")
 

--- a/api/service.go
+++ b/api/service.go
@@ -65,6 +65,14 @@ type remoteIdentity struct {
 	server pb.API_GetTokenServer
 }
 
+func (i *remoteIdentity) MarshalBinary() ([]byte, error) {
+	return nil, nil
+}
+
+func (i *remoteIdentity) UnmarshalBinary([]byte) error {
+	return nil
+}
+
 func (i *remoteIdentity) Sign(ctx context.Context, msg []byte) ([]byte, error) {
 	if err := i.server.Send(&pb.GetTokenReply{
 		Payload: &pb.GetTokenReply_Challenge{

--- a/core/thread/identity.go
+++ b/core/thread/identity.go
@@ -23,6 +23,9 @@ import (
 // In many cases, this will just be a private key, but callers
 // can use any setup that suits their needs.
 type Identity interface {
+	encoding.BinaryMarshaler
+	encoding.BinaryUnmarshaler
+
 	// Sign the given bytes cryptographically.
 	Sign(context.Context, []byte) ([]byte, error)
 	// GetPublic returns the public key paired with this identity.
@@ -39,6 +42,18 @@ type Libp2pIdentity struct {
 // NewLibp2pIdentity returns a new Libp2pIdentity.
 func NewLibp2pIdentity(key crypto.PrivKey) Identity {
 	return &Libp2pIdentity{PrivKey: key}
+}
+
+func (p *Libp2pIdentity) MarshalBinary() ([]byte, error) {
+	return crypto.MarshalPrivateKey(p.PrivKey)
+}
+
+func (p *Libp2pIdentity) UnmarshalBinary(bytes []byte) (err error) {
+	p.PrivKey, err = crypto.UnmarshalPrivateKey(bytes)
+	if err != nil {
+		return err
+	}
+	return err
 }
 
 func (p *Libp2pIdentity) Sign(_ context.Context, msg []byte) ([]byte, error) {
@@ -83,7 +98,7 @@ func NewLibp2pPubKey(key crypto.PubKey) PubKey {
 }
 
 func (p *Libp2pPubKey) MarshalBinary() ([]byte, error) {
-	return crypto.MarshalPublicKey(p)
+	return crypto.MarshalPublicKey(p.PubKey)
 }
 
 func (p *Libp2pPubKey) UnmarshalBinary(bytes []byte) (err error) {
@@ -95,7 +110,7 @@ func (p *Libp2pPubKey) UnmarshalBinary(bytes []byte) (err error) {
 }
 
 func (p *Libp2pPubKey) String() string {
-	bytes, err := crypto.MarshalPublicKey(p)
+	bytes, err := crypto.MarshalPublicKey(p.PubKey)
 	if err != nil {
 		panic(err)
 	}

--- a/db/bench_test.go
+++ b/db/bench_test.go
@@ -25,7 +25,7 @@ const (
 		"definitions": {
 		   "bench": {
 			  "required": [
-				 "ID",
+				 "_id",
 				 "Name",
 				 "Age"
 			  ],
@@ -36,7 +36,7 @@ const (
 				 "Age": {
 					"type": "integer"
 				 },
-				 "ID": {
+				 "_id": {
 					"type": "string"
 				 }
 			  },
@@ -83,7 +83,7 @@ func BenchmarkNoIndexCreate(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		var benchItem = []byte(`{"ID": "", "Name": "Lucas", "Age": 7}`)
+		var benchItem = []byte(`{"_id": "", "Name": "Lucas", "Age": 7}`)
 		var _, err = collection.Create(benchItem)
 		if err != nil {
 			b.Fatalf("Error creating instance: %s", err)
@@ -107,7 +107,7 @@ func BenchmarkIndexCreate(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		var benchItem = []byte(`{"ID": "", "Name": "Lucas", "Age": 7}`)
+		var benchItem = []byte(`{"_id": "", "Name": "Lucas", "Age": 7}`)
 		var _, err = collection.Create(benchItem)
 		if err != nil {
 			b.Fatalf("Error creating instance: %s", err)
@@ -121,14 +121,14 @@ func BenchmarkNoIndexSave(b *testing.B) {
 	collection, err := db.NewCollection(CollectionConfig{Name: "Dog", Schema: util.SchemaFromSchemaString(testBenchSchema)})
 	checkBenchErr(b, err)
 
-	var benchItem = []byte(`{"ID": "", "Name": "Lucas", "Age": 7}`)
+	var benchItem = []byte(`{"_id": "", "Name": "Lucas", "Age": 7}`)
 	res, err := collection.CreateMany([][]byte{benchItem})
 	checkBenchErr(b, err)
 
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		updated, err := sjson.SetBytes(benchItem, "ID", res[i].String())
+		updated, err := sjson.SetBytes(benchItem, "_id", res[i].String())
 		if err != nil {
 			b.Fatalf("Error setting instance id: %s", err)
 		}
@@ -156,14 +156,14 @@ func BenchmarkIndexSave(b *testing.B) {
 	})
 	checkBenchErr(b, err)
 
-	var benchItem = []byte(`{"ID": "", "Name": "Lucas", "Age": 7}`)
+	var benchItem = []byte(`{"_id": "", "Name": "Lucas", "Age": 7}`)
 	res, err := collection.CreateMany([][]byte{benchItem})
 	checkBenchErr(b, err)
 
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		updated, err := sjson.SetBytes(benchItem, "ID", res[i].String())
+		updated, err := sjson.SetBytes(benchItem, "_id", res[i].String())
 		if err != nil {
 			b.Fatalf("Error setting instance id: %s", err)
 		}
@@ -186,7 +186,7 @@ func BenchmarkNoIndexFind(b *testing.B) {
 
 	for j := 0; j < 10; j++ {
 		for i := 0; i < nameSize; i++ {
-			var benchItem = []byte(`{"ID": "", "Name": "Name", "Age": 7}`)
+			var benchItem = []byte(`{"_id": "", "Name": "Name", "Age": 7}`)
 			newItem, err := sjson.SetBytes(benchItem, "Name", fmt.Sprintf("Name%d", j))
 			if err != nil {
 				b.Fatalf("Error modifying instance: %s", err)
@@ -226,7 +226,7 @@ func BenchmarkIndexFind(b *testing.B) {
 
 	for j := 0; j < 10; j++ {
 		for i := 0; i < nameSize; i++ {
-			var benchItem = []byte(`{"ID": "", "Name": "Name", "Age": 7}`)
+			var benchItem = []byte(`{"_id": "", "Name": "Name", "Age": 7}`)
 			newItem, err := sjson.SetBytes(benchItem, "Name", fmt.Sprintf("Name%d", j))
 			if err != nil {
 				b.Fatalf("Error modifying instance: %s", err)

--- a/db/keytransform.go
+++ b/db/keytransform.go
@@ -108,6 +108,9 @@ func (t *txn) prepareQuery(q dsq.Query) (naive, child dsq.Query) {
 
 	// Always let the child handle the key prefix.
 	child.Prefix = t.ds.ConvertKey(ds.NewKey(child.Prefix)).String()
+	if child.SeekPrefix != "" {
+		child.SeekPrefix = t.ds.ConvertKey(ds.NewKey(child.SeekPrefix)).String()
+	}
 
 	// Check if the key transform is order-preserving so we can use the
 	// child datastore's built-in ordering.

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,9 @@ module github.com/textileio/go-threads
 
 go 1.14
 
-replace github.com/ipfs/go-datastore => ../go-datastore
-replace github.com/ipfs/go-ds-badger => ../go-ds-badger
+replace github.com/ipfs/go-datastore v0.4.4 => github.com/textileio/go-datastore v0.4.5-0.20200728205504-ffeb3591b248
+
+replace github.com/ipfs/go-ds-badger v0.2.4 => github.com/textileio/go-ds-badger v0.2.5-0.20200728212847-1ec9ac5e644c
 
 require (
 	github.com/AndreasBriese/bbloom v0.0.0-20190823232136-616930265c33 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/textileio/go-threads
 
 go 1.14
 
+replace github.com/ipfs/go-datastore => ../go-datastore
+replace github.com/ipfs/go-ds-badger => ../go-ds-badger
+
 require (
 	github.com/AndreasBriese/bbloom v0.0.0-20190823232136-616930265c33 // indirect
 	// agl/ed25519 only used in tests for backward compatibility, *do not* use in production code.

--- a/go.sum
+++ b/go.sum
@@ -199,8 +199,6 @@ github.com/ipfs/go-datastore v0.3.1 h1:SS1t869a6cctoSYmZXUk8eL6AzVXgASmKIWFNQkQ1
 github.com/ipfs/go-datastore v0.3.1/go.mod h1:w38XXW9kVFNp57Zj5knbKWM2T+KOZCGDRVNdgPHtbHw=
 github.com/ipfs/go-datastore v0.4.0/go.mod h1:SX/xMIKoCszPqp+z9JhPYCmoOoXTvaa13XEbGtsFUhA=
 github.com/ipfs/go-datastore v0.4.1/go.mod h1:SX/xMIKoCszPqp+z9JhPYCmoOoXTvaa13XEbGtsFUhA=
-github.com/ipfs/go-datastore v0.4.4 h1:rjvQ9+muFaJ+QZ7dN5B1MSDNQ0JVZKkkES/rMZmA8X8=
-github.com/ipfs/go-datastore v0.4.4/go.mod h1:SX/xMIKoCszPqp+z9JhPYCmoOoXTvaa13XEbGtsFUhA=
 github.com/ipfs/go-detect-race v0.0.1 h1:qX/xay2W3E4Q1U7d9lNs1sU9nvguX0a7319XbyQ6cOk=
 github.com/ipfs/go-detect-race v0.0.1/go.mod h1:8BNT7shDZPo99Q74BpGMK+4D8Mn4j46UU0LZ723meps=
 github.com/ipfs/go-ds-badger v0.0.2/go.mod h1:Y3QpeSFWQf6MopLTiZD+VT6IC1yZqaGmjvRcKeSGij8=
@@ -210,8 +208,6 @@ github.com/ipfs/go-ds-badger v0.0.7 h1:NMyh88Q50HG6/S2YD58DLkq0c0/ZQPMbSojONH+PR
 github.com/ipfs/go-ds-badger v0.0.7/go.mod h1:qt0/fWzZDoPW6jpQeqUjR5kBfhDNB65jd9YlmAvpQBk=
 github.com/ipfs/go-ds-badger v0.2.1/go.mod h1:Tx7l3aTph3FMFrRS838dcSJh+jjA7cX9DrGVwx/NOwE=
 github.com/ipfs/go-ds-badger v0.2.3/go.mod h1:pEYw0rgg3FIrywKKnL+Snr+w/LjJZVMTBRn4FS6UHUk=
-github.com/ipfs/go-ds-badger v0.2.4 h1:UPGB0y7luFHk+mY/tUZrif/272M8o+hFsW+avLUeWrM=
-github.com/ipfs/go-ds-badger v0.2.4/go.mod h1:pEYw0rgg3FIrywKKnL+Snr+w/LjJZVMTBRn4FS6UHUk=
 github.com/ipfs/go-ds-leveldb v0.0.1/go.mod h1:feO8V3kubwsEF22n0YRQCffeb79OOYIykR4L04tMOYc=
 github.com/ipfs/go-ds-leveldb v0.1.0 h1:OsCuIIh1LMTk4WIQ1UJH7e3j01qlOP+KWVhNS6lBDZY=
 github.com/ipfs/go-ds-leveldb v0.1.0/go.mod h1:hqAW8y4bwX5LWcCtku2rFNX3vjDZCy5LZCg+cSZvYb8=
@@ -724,6 +720,10 @@ github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFdE=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
+github.com/textileio/go-datastore v0.4.5-0.20200728205504-ffeb3591b248 h1:X4S0Y+yX1eZB1wx8Vm4spdGoSgCgPQJB5iuSY2hECXo=
+github.com/textileio/go-datastore v0.4.5-0.20200728205504-ffeb3591b248/go.mod h1:eXTcaaiN6uOlVCLS9GjJUJtlvJfM3xk23w3fyfrmmJs=
+github.com/textileio/go-ds-badger v0.2.5-0.20200728212847-1ec9ac5e644c h1:KdgC7TSGWvvNfPtzgHtzNdeBIKUBjCSJbW8luqIPTs4=
+github.com/textileio/go-ds-badger v0.2.5-0.20200728212847-1ec9ac5e644c/go.mod h1:xmAMBD9J5eVxClKrKggixADgZ8zMeOoG7RPnOuVRegg=
 github.com/tidwall/gjson v1.3.5 h1:2oW9FBNu8qt9jy5URgrzsVx/T/KSn3qn/smJQ0crlDQ=
 github.com/tidwall/gjson v1.3.5/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=
 github.com/tidwall/match v1.0.1 h1:PnKP62LPNxHKTwvHHZZzdOAOCtsJTjo6dZLCwpKm5xc=

--- a/net/api/service.go
+++ b/net/api/service.go
@@ -62,6 +62,14 @@ type remoteIdentity struct {
 	server pb.API_GetTokenServer
 }
 
+func (i *remoteIdentity) MarshalBinary() ([]byte, error) {
+	return nil, nil
+}
+
+func (i *remoteIdentity) UnmarshalBinary([]byte) error {
+	return nil
+}
+
 func (i *remoteIdentity) Sign(ctx context.Context, msg []byte) ([]byte, error) {
 	if err := i.server.Send(&pb.GetTokenReply{
 		Payload: &pb.GetTokenReply_Challenge{

--- a/net/api/service.go
+++ b/net/api/service.go
@@ -105,6 +105,10 @@ func (i *remoteIdentity) GetPublic() thread.PubKey {
 	return i.pk
 }
 
+func (i *remoteIdentity) Decrypt(context.Context, []byte) ([]byte, error) {
+	return nil, nil // no-op
+}
+
 func (s *Service) GetToken(server pb.API_GetTokenServer) error {
 	log.Debugf("received get token request")
 


### PR DESCRIPTION
### DB
- Adds more options to `ds.Query`:
  - `Seek` to an instance `ID` before running a query
  - `Skip`  is an alternative way to paginate (not as efficient as `Seek`, but a better fit in cases where the IDs aren't dictating result order)
  - `Limit` the number of query results
- Adds a couple `ds.Query` helpers:
  - `OrderByID`: Specifies ascending ID order for the query results
  - `OrderByIDDesc`: Specifies descending ID order for the query results

### Core
- Adds `encoding.BinaryMarshaler` and `encoding.BinaryUnmarshaler` to `thread.Identity`
- Adds `Decrypt` to `thread.Identity`
- Adds `Encrypt` to `thread.PubKey`