### PR TITLE
Make pubsub optional

### DIFF
--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -746,7 +746,11 @@ func makeServer(t *testing.T) (ma.Multiaddr, func()) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	n, err := common.DefaultNetwork(dir, common.WithNetDebug(true), common.WithNetHostAddr(util.FreeLocalAddr()))
+	n, err := common.DefaultNetwork(
+		dir,
+		common.WithNetHostAddr(util.FreeLocalAddr()),
+		common.WithNetPubSub(true),
+		common.WithNetDebug(true))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/common/common.go
+++ b/common/common.go
@@ -120,7 +120,8 @@ func DefaultNetwork(repoPath string, opts ...NetOption) (NetBoostrapper, error) 
 
 	// Build a network
 	api, err := net.NewNetwork(ctx, h, lite.BlockStore(), lite, tstore, net.Config{
-		Debug: config.Debug,
+		Debug:  config.Debug,
+		PubSub: !config.PubSubDisabled,
 	}, config.GRPCOptions...)
 	if err != nil {
 		cancel()
@@ -144,10 +145,11 @@ func DefaultNetwork(repoPath string, opts ...NetOption) (NetBoostrapper, error) 
 }
 
 type NetConfig struct {
-	HostAddr    ma.Multiaddr
-	ConnManager cconnmgr.ConnManager
-	Debug       bool
-	GRPCOptions []grpc.ServerOption
+	HostAddr       ma.Multiaddr
+	ConnManager    cconnmgr.ConnManager
+	Debug          bool
+	GRPCOptions    []grpc.ServerOption
+	PubSubDisabled bool
 }
 
 type NetOption func(c *NetConfig) error
@@ -176,6 +178,13 @@ func WithNetDebug(enabled bool) NetOption {
 func WithNetGRPCOptions(opts ...grpc.ServerOption) NetOption {
 	return func(c *NetConfig) error {
 		c.GRPCOptions = opts
+		return nil
+	}
+}
+
+func WithPubSubDisabled() NetOption {
+	return func(c *NetConfig) error {
+		c.PubSubDisabled = true
 		return nil
 	}
 }

--- a/common/common.go
+++ b/common/common.go
@@ -121,7 +121,7 @@ func DefaultNetwork(repoPath string, opts ...NetOption) (NetBoostrapper, error) 
 	// Build a network
 	api, err := net.NewNetwork(ctx, h, lite.BlockStore(), lite, tstore, net.Config{
 		Debug:  config.Debug,
-		PubSub: !config.PubSubDisabled,
+		PubSub: config.PubSub,
 	}, config.GRPCOptions...)
 	if err != nil {
 		cancel()
@@ -145,11 +145,11 @@ func DefaultNetwork(repoPath string, opts ...NetOption) (NetBoostrapper, error) 
 }
 
 type NetConfig struct {
-	HostAddr       ma.Multiaddr
-	ConnManager    cconnmgr.ConnManager
-	Debug          bool
-	GRPCOptions    []grpc.ServerOption
-	PubSubDisabled bool
+	HostAddr    ma.Multiaddr
+	ConnManager cconnmgr.ConnManager
+	Debug       bool
+	GRPCOptions []grpc.ServerOption
+	PubSub      bool
 }
 
 type NetOption func(c *NetConfig) error
@@ -182,9 +182,9 @@ func WithNetGRPCOptions(opts ...grpc.ServerOption) NetOption {
 	}
 }
 
-func WithPubSubDisabled() NetOption {
+func WithNetPubSub() NetOption {
 	return func(c *NetConfig) error {
-		c.PubSubDisabled = true
+		c.PubSub = true
 		return nil
 	}
 }

--- a/common/common.go
+++ b/common/common.go
@@ -182,9 +182,9 @@ func WithNetGRPCOptions(opts ...grpc.ServerOption) NetOption {
 	}
 }
 
-func WithNetPubSub() NetOption {
+func WithNetPubSub(enabled bool) NetOption {
 	return func(c *NetConfig) error {
-		c.PubSub = true
+		c.PubSub = enabled
 		return nil
 	}
 }

--- a/db/db.go
+++ b/db/db.go
@@ -87,7 +87,7 @@ func NewDB(ctx context.Context, network app.Net, id thread.ID, opts ...NewOption
 		opt(args)
 	}
 
-	if _, err := network.CreateThread(ctx, id, net.WithNewThreadToken(args.Token), net.WithThreadKey(args.ThreadKey)); err != nil {
+	if _, err := network.CreateThread(ctx, id, net.WithNewThreadToken(args.Token), net.WithThreadKey(args.ThreadKey), net.WithLogKey(args.LogKey)); err != nil {
 		if !errors.Is(err, lstore.ErrThreadExists) {
 			return nil, err
 		}

--- a/db/options.go
+++ b/db/options.go
@@ -7,6 +7,7 @@ import (
 	"github.com/dgraph-io/badger/options"
 	ds "github.com/ipfs/go-datastore"
 	badger "github.com/ipfs/go-ds-badger"
+	"github.com/libp2p/go-libp2p-core/crypto"
 	core "github.com/textileio/go-threads/core/db"
 	"github.com/textileio/go-threads/core/thread"
 	"github.com/textileio/go-threads/jsonpatcher"
@@ -43,6 +44,7 @@ type NewOptions struct {
 	LowMem      bool
 	Debug       bool
 	ThreadKey   thread.Key
+	LogKey      crypto.Key
 }
 
 // NewOption specifies a new db option.
@@ -73,6 +75,16 @@ func WithNewToken(t thread.Token) NewOption {
 func WithNewThreadKey(key thread.Key) NewOption {
 	return func(o *NewOptions) {
 		o.ThreadKey = key
+	}
+}
+
+// WithNewLogKey is the public or private key used to write log records.
+// If this is just a public key, the service itself won't be able to create records.
+// In other words, all records must be pre-created and added with AddRecord.
+// If no log key is provided, one will be created internally.
+func WithNewLogKey(key crypto.Key) NewOption {
+	return func(o *NewOptions) {
+		o.LogKey = key
 	}
 }
 

--- a/examples/chat/main.go
+++ b/examples/chat/main.go
@@ -96,6 +96,7 @@ func main() {
 	net, err = common.DefaultNetwork(
 		*repo,
 		common.WithNetHostAddr(hostAddr),
+		common.WithNetPubSub(true),
 		common.WithNetDebug(*debug))
 	if err != nil {
 		log.Fatal(err)

--- a/net/api/client/client_test.go
+++ b/net/api/client/client_test.go
@@ -415,6 +415,7 @@ func makeServer(t *testing.T) (ma.Multiaddr, ma.Multiaddr, func()) {
 	n, err := common.DefaultNetwork(
 		dir,
 		common.WithNetHostAddr(hostAddr),
+		common.WithNetPubSub(true),
 		common.WithNetDebug(true))
 	if err != nil {
 		t.Fatal(err)

--- a/net/client.go
+++ b/net/client.go
@@ -377,9 +377,12 @@ func (s *server) pushRecord(ctx context.Context, id thread.ID, lid peer.ID, rec 
 	}
 
 	// Finally, publish to the thread's topic
-	if err = s.ps.Publish(ctx, id, req); err != nil {
-		log.Errorf("error publishing record: %s", err)
+	if s.ps != nil {
+		if err = s.ps.Publish(ctx, id, req); err != nil {
+			log.Errorf("error publishing record: %s", err)
+		}
 	}
+
 	return nil
 }
 

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -437,7 +437,8 @@ func makeNetwork(t *testing.T) core.Net {
 		dag.NewDAGService(bsrv),
 		tstore.NewLogstore(),
 		Config{
-			Debug: true,
+			Debug:  true,
+			PubSub: true,
 		})
 	if err != nil {
 		t.Fatal(err)

--- a/threadsd/main.go
+++ b/threadsd/main.go
@@ -36,6 +36,7 @@ func main() {
 	connHighWater := fs.Int("connHighWater", 400, "High watermark of libp2p connections that'll be maintained")
 	connGracePeriod := fs.Duration("connGracePeriod", time.Second*20, "Duration a newly opened connection is given before it becomes subject to pruning")
 	keepAliveInterval := fs.Duration("keepAliveInterval", time.Second*5, "Enables websocket keepalive pinging with the specified timeout interval. Configured interval must be >= 1s.")
+	enableNetPubsub := fs.Bool("enableNetPubsub", false, "Enable thread networking over libp2p pubsub")
 	debug := fs.Bool("debug", false, "Enable debug logging")
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		log.Fatal(err)
@@ -65,12 +66,18 @@ func main() {
 	log.Debugf("hostAddr: %v", *hostAddrStr)
 	log.Debugf("apiAddr: %v", *apiAddrStr)
 	log.Debugf("apiProxyAddr: %v", *apiProxyAddrStr)
+	log.Debugf("connLowWater: %v", *connLowWater)
+	log.Debugf("connHighWater: %v", *connHighWater)
+	log.Debugf("connGracePeriod: %v", *connGracePeriod)
+	log.Debugf("keepAliveInterval: %v", *keepAliveInterval)
+	log.Debugf("enableNetPubsub: %v", *enableNetPubsub)
 	log.Debugf("debug: %v", *debug)
 
 	n, err := common.DefaultNetwork(
 		*repo,
 		common.WithNetHostAddr(hostAddr),
 		common.WithConnectionManager(connmgr.NewConnManager(*connLowWater, *connHighWater, *connGracePeriod)),
+		common.WithNetPubSub(*enableNetPubsub),
 		common.WithNetDebug(*debug))
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Running nodes for some time we've detected that pubsub mechanism combined with threads may produce a lot of unneccesary traffic.
Assuming that every thread has corresponding topic propagated through the pubsub, long-running high-degree nodes accumulate a lot of topics during its lifetime. When some other node establishes connection, it will respond with a huge hello-packet, containing all the topics seen so far, mostly irrelevant to the caller.
Taking into account that pubsub is in fact a secondary channel of event propagation, we can alleviate the problem by making it optional. Pubsub stays enabled by default, so the change won't affect any existing setup, and there is a new NetOption allowing to disable pubsub subsystem in threads completely.
