### PR TITLE
fix logging and avoid replace for textile repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/ipfs/go-ipld-cbor v0.0.4
 	github.com/ipfs/go-ipld-format v0.2.0
 	github.com/ipfs/go-log v1.0.4
+	github.com/ipfs/go-log/v2 v2.1.1
 	github.com/ipfs/go-merkledag v0.3.2
 	github.com/libp2p/go-libp2p v0.10.3
 	github.com/libp2p/go-libp2p-connmgr v0.2.4

--- a/threadsd/main.go
+++ b/threadsd/main.go
@@ -55,7 +55,9 @@ func main() {
 		log.Fatal(err)
 	}
 
-	util.SetupDefaultLoggingConfig(*repo)
+	if err := util.SetupDefaultLoggingConfig(*repo); err != nil {
+		log.Fatal(err)
+	}
 	if *debug {
 		if err := logging.SetLogLevel("threadsd", "debug"); err != nil {
 			log.Fatal(err)

--- a/util/util.go
+++ b/util/util.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/alecthomas/jsonschema"
 	ipfslite "github.com/hsanjuan/ipfs-lite"
-	logging "github.com/ipfs/go-log"
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
 	swarm "github.com/libp2p/go-libp2p-swarm"
@@ -38,11 +38,20 @@ func CanDial(addr ma.Multiaddr, s *swarm.Swarm) bool {
 }
 
 // SetupDefaultLoggingConfig sets up a standard logging configuration.
-func SetupDefaultLoggingConfig(repoPath string) {
-	_ = os.Setenv("GOLOG_LOG_FMT", "color")
-	_ = os.Setenv("GOLOG_FILE", filepath.Join(repoPath, "log", "threads.log"))
-	logging.SetupLogging()
-	logging.SetAllLoggers(logging.LevelError)
+func SetupDefaultLoggingConfig(repoPath string) error {
+	folder := filepath.Join(repoPath, "log")
+	if err := os.MkdirAll(folder, os.ModePerm); err != nil {
+		return err
+	}
+	c := logging.Config{
+		Format: logging.ColorizedOutput,
+		Stderr: true,
+		File:   filepath.Join(folder, "threads.log"),
+		Level:  logging.LevelError,
+	}
+	logging.SetupLogging(c)
+
+	return nil
 }
 
 // SetLogLevels sets levels for the given systems.


### PR DESCRIPTION
Trying to make `hubd` have working saving logs also to a file, went into a deep rabbit hole.

`hubd` uses an util function on `go-threads` to setup logging. This `SetupLogging` function used env vars to configure the file path output. At some point when we updated `go-log` from `v1.0.0/v1.0.1` to `v1.0.4`, and then something bad happened.

After `ipfs/go-log@v1.0.1` there is a [commit](https://github.com/ipfs/go-log/commit/e1c5faa6442f373b952970b80cb97ec09fd694d5#diff-17a9f1db2982c66c910a1e06f92e6489L34) that from `v1.0.2` and forward makes the `GOLOG_FILE` style of configuring the output file log break the way we are using it.

In that change, they use `go-log/v2` as the underlying logging library, which is OK. But `go-log/v2` only recognizes `GOLOG_FILE` [at `init()` time](https://github.com/ipfs/go-log/blob/0016c0b4b3e4f13beb8700f91d56af9dbf91aa54/setup.go#L16). The underlying "old" `loggingv1.SetupLogging()` doesn't re-setup things to take this into consideration. So changing the env var after program bootstrap (after `init()` calls), doesn't have the intended effect.

In short, I fixed our setup function to call again the same function that gets called in `init()` but with explicit args. The previous API of go-log which used env vars backfired.

If the above is confusing, don't worry... it is.

Apart from that, I updated `go-libp2p-peerstore` to `v0.2.6`. This new tag already includes a commit I made to fix a race condition that we solved with a `replace` in [textile go.mod](https://github.com/textileio/textile/blob/0f87b8f7165919941ba0d132885132d0a124a19c/go.mod#L83). So, whenever we update `textile` to a new `go-threads` tag that includes this PR, we could avoid that replace.
