### PR TITLE
Set gRPC dial-options

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -121,7 +121,7 @@ func DefaultNetwork(repoPath string, opts ...NetOption) (NetBoostrapper, error) 
 	api, err := net.NewNetwork(ctx, h, lite.BlockStore(), lite, tstore, net.Config{
 		Debug:  config.Debug,
 		PubSub: config.PubSub,
-	}, config.GRPCOptions, config.GRPCInternalOptions)
+	}, config.GRPCServerOptions, config.GRPCDialOptions)
 	if err != nil {
 		cancel()
 		if err := logstore.Close(); err != nil {
@@ -144,12 +144,12 @@ func DefaultNetwork(repoPath string, opts ...NetOption) (NetBoostrapper, error) 
 }
 
 type NetConfig struct {
-	HostAddr            ma.Multiaddr
-	ConnManager         cconnmgr.ConnManager
-	Debug               bool
-	GRPCOptions         []grpc.ServerOption
-	GRPCInternalOptions []grpc.DialOption
-	PubSub              bool
+	HostAddr          ma.Multiaddr
+	ConnManager       cconnmgr.ConnManager
+	Debug             bool
+	GRPCServerOptions []grpc.ServerOption
+	GRPCDialOptions   []grpc.DialOption
+	PubSub            bool
 }
 
 type NetOption func(c *NetConfig) error
@@ -175,16 +175,16 @@ func WithNetDebug(enabled bool) NetOption {
 	}
 }
 
-func WithNetGRPCOptions(opts ...grpc.ServerOption) NetOption {
+func WithNetGRPCServerOptions(opts ...grpc.ServerOption) NetOption {
 	return func(c *NetConfig) error {
-		c.GRPCOptions = opts
+		c.GRPCServerOptions = opts
 		return nil
 	}
 }
 
-func WithNetGRPCInternalOptions(opts ...grpc.DialOption) NetOption {
+func WithNetGRPCDialOptions(opts ...grpc.DialOption) NetOption {
 	return func(c *NetConfig) error {
-		c.GRPCInternalOptions = opts
+		c.GRPCDialOptions = opts
 		return nil
 	}
 }

--- a/common/common.go
+++ b/common/common.go
@@ -121,7 +121,7 @@ func DefaultNetwork(repoPath string, opts ...NetOption) (NetBoostrapper, error) 
 	api, err := net.NewNetwork(ctx, h, lite.BlockStore(), lite, tstore, net.Config{
 		Debug:  config.Debug,
 		PubSub: config.PubSub,
-	}, config.GRPCOptions...)
+	}, config.GRPCOptions, config.GRPCInternalOptions)
 	if err != nil {
 		cancel()
 		if err := logstore.Close(); err != nil {
@@ -144,11 +144,12 @@ func DefaultNetwork(repoPath string, opts ...NetOption) (NetBoostrapper, error) 
 }
 
 type NetConfig struct {
-	HostAddr    ma.Multiaddr
-	ConnManager cconnmgr.ConnManager
-	Debug       bool
-	GRPCOptions []grpc.ServerOption
-	PubSub      bool
+	HostAddr            ma.Multiaddr
+	ConnManager         cconnmgr.ConnManager
+	Debug               bool
+	GRPCOptions         []grpc.ServerOption
+	GRPCInternalOptions []grpc.DialOption
+	PubSub              bool
 }
 
 type NetOption func(c *NetConfig) error
@@ -177,6 +178,13 @@ func WithNetDebug(enabled bool) NetOption {
 func WithNetGRPCOptions(opts ...grpc.ServerOption) NetOption {
 	return func(c *NetConfig) error {
 		c.GRPCOptions = opts
+		return nil
+	}
+}
+
+func WithNetGRPCInternalOptions(opts ...grpc.DialOption) NetOption {
+	return func(c *NetConfig) error {
+		c.GRPCInternalOptions = opts
 		return nil
 	}
 }

--- a/net/client.go
+++ b/net/client.go
@@ -404,7 +404,7 @@ func (s *server) dial(peerID peer.ID) (pb.ServiceClient, error) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), DialTimeout)
 	defer cancel()
-	conn, err := grpc.DialContext(ctx, peerID.Pretty(), s.getLibp2pDialer(), grpc.WithInsecure())
+	conn, err := grpc.DialContext(ctx, peerID.Pretty(), s.opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/net/client.go
+++ b/net/client.go
@@ -111,13 +111,13 @@ func (s *server) pushLog(ctx context.Context, id thread.ID, lg thread.LogInfo, p
 
 	client, err := s.dial(pid)
 	if err != nil {
-		return fmt.Errorf("dial %s failed: %s", pid, err)
+		return fmt.Errorf("dial %s failed: %w", pid, err)
 	}
 	cctx, cancel := context.WithTimeout(ctx, PushTimeout)
 	defer cancel()
 	_, err = client.PushLog(cctx, lreq)
 	if err != nil {
-		return fmt.Errorf("push log to %s failed: %s", pid, err)
+		return fmt.Errorf("push log to %s failed: %w", pid, err)
 	}
 	return err
 }
@@ -417,12 +417,12 @@ func (s *server) getLibp2pDialer() grpc.DialOption {
 	return grpc.WithContextDialer(func(ctx context.Context, peerIDStr string) (nnet.Conn, error) {
 		id, err := peer.Decode(peerIDStr)
 		if err != nil {
-			return nil, fmt.Errorf("grpc tried to dial non peerID: %s", err)
+			return nil, fmt.Errorf("grpc tried to dial non peerID: %w", err)
 		}
 
 		conn, err := gostream.Dial(ctx, s.net.host, id, thread.Protocol)
 		if err != nil {
-			return nil, fmt.Errorf("gostream dial failed: %s", err.Error())
+			return nil, fmt.Errorf("gostream dial failed: %w", err)
 		}
 
 		return conn, nil

--- a/net/net.go
+++ b/net/net.go
@@ -89,8 +89,8 @@ func NewNetwork(
 	ds format.DAGService,
 	ls lstore.Logstore,
 	conf Config,
-	serverOpts []grpc.ServerOption,
-	internalOpts []grpc.DialOption,
+	serverOptions []grpc.ServerOption,
+	dialOptions []grpc.DialOption,
 ) (app.Net, error) {
 	var err error
 	if conf.Debug {
@@ -108,7 +108,7 @@ func NewNetwork(
 		host:       h,
 		bstore:     bstore,
 		store:      ls,
-		rpc:        grpc.NewServer(serverOpts...),
+		rpc:        grpc.NewServer(serverOptions...),
 		bus:        broadcast.NewBroadcaster(0),
 		connectors: make(map[thread.ID]*app.Connector),
 		ctx:        ctx,
@@ -116,7 +116,7 @@ func NewNetwork(
 		pullLocks:  make(map[thread.ID]chan struct{}),
 	}
 
-	t.server, err = newServer(t, conf.PubSub, internalOpts...)
+	t.server, err = newServer(t, conf.PubSub, dialOptions...)
 	if err != nil {
 		return nil, err
 	}

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -447,7 +447,7 @@ func makeNetwork(t *testing.T) core.Net {
 		Config{
 			Debug:  true,
 			PubSub: true,
-		})
+		}, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Sometimes it is very helpful to be able to set gRPC-parameters for internal communication between nodes, e.g. message size limits, gRPC interceptors etc.
And it'd be nice to have a distinct timeouts for various operations (dial/pull/push), that could be redefined by application.
