### PR TITLE
Reuse JavaScript VM and other nits

### DIFF
--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -245,8 +245,10 @@ func TestClient_GetCollectionInfo(t *testing.T) {
 		}
 		sb, err := json.Marshal(jschema)
 		checkErr(t, err)
-		if !bytes.Equal(info.Schema, sb) {
-			t.Fatalf("expected %s, but got %s", string(sb), string(info.Schema))
+		isb, err := json.Marshal(info.Schema)
+		checkErr(t, err)
+		if !bytes.Equal(isb, sb) {
+			t.Fatalf("expected %s, but got %s", string(sb), string(isb))
 		}
 		if len(info.Indexes) != 1 {
 			t.Fatalf("expected 1 indexes, but got %v", len(info.Indexes))

--- a/api/service.go
+++ b/api/service.go
@@ -402,9 +402,11 @@ func (s *Service) GetCollectionInfo(ctx context.Context, req *pb.GetCollectionIn
 		return nil, err
 	}
 	return &pb.GetCollectionInfoReply{
-		Name:    collection.GetName(),
-		Schema:  collection.GetSchema(),
-		Indexes: indexesToPb(collection.GetIndexes()),
+		Name:           collection.GetName(),
+		Schema:         collection.GetSchema(),
+		Indexes:        indexesToPb(collection.GetIndexes()),
+		WriteValidator: string(collection.GetWriteValidator()),
+		ReadFilter:     string(collection.GetReadFilter()),
 	}, nil
 }
 
@@ -454,9 +456,11 @@ func (s *Service) ListCollections(ctx context.Context, req *pb.ListCollectionsRe
 	pblist := make([]*pb.GetCollectionInfoReply, len(list))
 	for i, c := range list {
 		pblist[i] = &pb.GetCollectionInfoReply{
-			Name:    c.GetName(),
-			Schema:  c.GetSchema(),
-			Indexes: indexesToPb(c.GetIndexes()),
+			Name:           c.GetName(),
+			Schema:         c.GetSchema(),
+			Indexes:        indexesToPb(c.GetIndexes()),
+			WriteValidator: string(c.GetWriteValidator()),
+			ReadFilter:     string(c.GetReadFilter()),
 		}
 	}
 	return &pb.ListCollectionsReply{Collections: pblist}, nil

--- a/db/collection_test.go
+++ b/db/collection_test.go
@@ -443,6 +443,40 @@ func TestGetSchema(t *testing.T) {
 	}
 }
 
+func TestGetWriteValidator(t *testing.T) {
+	t.Parallel()
+	db, clean := createTestDB(t)
+	defer clean()
+	schema := util.SchemaFromInstance(&Person2{}, false)
+	wv := "return true"
+	c, err := db.NewCollection(CollectionConfig{
+		Name:           "Person",
+		Schema:         schema,
+		WriteValidator: wv,
+	})
+	checkErr(t, err)
+	if !bytes.Equal(c.GetWriteValidator(), []byte(wv)) {
+		t.Fatal("got write validator does not match original")
+	}
+}
+
+func TestGetReadFilter(t *testing.T) {
+	t.Parallel()
+	db, clean := createTestDB(t)
+	defer clean()
+	schema := util.SchemaFromInstance(&Person2{}, false)
+	rf := "return instance"
+	c, err := db.NewCollection(CollectionConfig{
+		Name:       "Person",
+		Schema:     schema,
+		ReadFilter: rf,
+	})
+	checkErr(t, err)
+	if !bytes.Equal(c.GetReadFilter(), []byte(rf)) {
+		t.Fatal("got read filter does not match original")
+	}
+}
+
 func TestGetIndexes(t *testing.T) {
 	t.Parallel()
 	db, clean := createTestDB(t)

--- a/db/db.go
+++ b/db/db.go
@@ -392,13 +392,13 @@ func (d *DB) saveCollection(c *Collection) error {
 	if err := d.datastore.Put(dsSchemas.ChildString(c.name), c.GetSchema()); err != nil {
 		return err
 	}
-	if c.writeValidator != nil {
-		if err := d.datastore.Put(dsValidators.ChildString(c.name), c.writeValidator); err != nil {
+	if c.rawWriteValidator != nil {
+		if err := d.datastore.Put(dsValidators.ChildString(c.name), c.rawWriteValidator); err != nil {
 			return err
 		}
 	}
-	if c.readFilter != nil {
-		if err := d.datastore.Put(dsFilters.ChildString(c.name), c.readFilter); err != nil {
+	if c.rawReadFilter != nil {
+		if err := d.datastore.Put(dsFilters.ChildString(c.name), c.rawReadFilter); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Closes #423 

- Removes some cumbersome client types
- Each collection stores its own JS VM and compiled JS functions for resuse
- Properly returns the `writeValidator` and `readFilter` with other collection info in the gRPC API