### PR TITLE
Token validate fatal error fix

### DIFF
--- a/core/thread/identity.go
+++ b/core/thread/identity.go
@@ -214,13 +214,14 @@ func (t Token) PubKey() (PubKey, error) {
 // If token is not present, both the returned public key and error will be nil.
 func (t Token) Validate(issuer crypto.PrivKey) (PubKey, error) {
 	var ok bool
+	if t == "" {
+		return nil, nil
+	}
 	issuer, ok = issuer.(*crypto.Ed25519PrivateKey)
 	if !ok {
 		log.Fatal("issuer must be an Ed25519PrivateKey")
 	}
-	if t == "" {
-		return nil, nil
-	}
+
 	keyfunc := func(*jwt.Token) (interface{}, error) {
 		return issuer.GetPublic(), nil
 	}


### PR DESCRIPTION
We've faced the problem. In case you have some `net.Validate()` requests in the background and do `netBoostrapper.Close()` this leads to a fatal error because datastore is closed and it is not possible to retrieve the identity.

Looks like it safe to have the nil check before