### PR TITLE
jsonpatcher: empty interface timestamp

### DIFF
--- a/api/pb/javascript/package-lock.json
+++ b/api/pb/javascript/package-lock.json
@@ -28,9 +28,9 @@
       "integrity": "sha512-ZIf3qfLFayVrPvAjeKKxO5FRF1/NwRxt6Dko+fWEMuHwHbZx8/fcaAao9b0wCM6kr8qeg2te8XTpyuvKuD9aKw=="
     },
     "ts-protoc-gen": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/ts-protoc-gen/-/ts-protoc-gen-0.12.0.tgz",
-      "integrity": "sha512-V7jnICJxKqalBrnJSMTW5tB9sGi48gOC325bfcM7TDNUItVOlaMM//rQmuo49ybipk/SyJTnWXgtJnhHCevNJw==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/ts-protoc-gen/-/ts-protoc-gen-0.13.0.tgz",
+      "integrity": "sha512-j18X4rkDBbG/ZHUJy88WFeZP6mStGow5uREaohowlHXTu3/N7WcpyPhb7Vh6wN38ERmc/AkT9gqT98+vtlRhJA==",
       "dev": true,
       "requires": {
         "google-protobuf": "^3.6.1"

--- a/api/pb/javascript/package.json
+++ b/api/pb/javascript/package.json
@@ -20,6 +20,6 @@
     "google-protobuf": "^3.13.0"
   },
   "devDependencies": {
-    "ts-protoc-gen": "^0.12.0"
+    "ts-protoc-gen": "^0.13.0"
   }
 }

--- a/core/thread/identity.go
+++ b/core/thread/identity.go
@@ -213,6 +213,9 @@ func (t Token) PubKey() (PubKey, error) {
 // If token is present and was issued by issuer (is valid), the embedded public key is returned.
 // If token is not present, both the returned public key and error will be nil.
 func (t Token) Validate(issuer crypto.PrivKey) (PubKey, error) {
+	if issuer == nil {
+		return nil, fmt.Errorf("cannot validate with nil issuer")
+	}
 	var ok bool
 	issuer, ok = issuer.(*crypto.Ed25519PrivateKey)
 	if !ok {

--- a/jsonpatcher/jsonpatcher.go
+++ b/jsonpatcher/jsonpatcher.go
@@ -51,8 +51,7 @@ type operation struct {
 	JSONPatch  []byte
 }
 
-type jsonPatcher struct {
-}
+type jsonPatcher struct{}
 
 var _ core.EventCodec = (*jsonPatcher)(nil)
 
@@ -120,7 +119,7 @@ func (jp *jsonPatcher) Reduce(events []core.Event, datastore ds.TxnDatastore, ba
 			return false
 		}
 
-		return ei.Timestamp < ej.Timestamp
+		return ei.time().Before(ej.time())
 	})
 
 	actions := make([]core.ReduceAction, len(events))
@@ -239,18 +238,34 @@ func deleteEvent(id core.InstanceID) (*operation, error) {
 }
 
 type patchEvent struct {
-	Timestamp      int64
+	Timestamp      interface{}
 	ID             core.InstanceID
 	CollectionName string
 	Patch          operation
 }
 
 func (je patchEvent) Time() []byte {
-	t := je.Timestamp
+	var nanos int64
+	switch ts := je.Timestamp.(type) {
+	case time.Time:
+		nanos = ts.UnixNano()
+	case int64:
+		nanos = ts
+	}
 	buf := new(bytes.Buffer)
 	// Use big endian to preserve lexicographic sorting
-	_ = binary.Write(buf, binary.BigEndian, t)
+	_ = binary.Write(buf, binary.BigEndian, nanos)
 	return buf.Bytes()
+}
+
+func (je patchEvent) time() (t time.Time) {
+	switch ts := je.Timestamp.(type) {
+	case time.Time:
+		t = ts
+	case int:
+		t = time.Unix(0, int64(ts))
+	}
+	return t
 }
 
 func (je patchEvent) InstanceID() core.InstanceID {
@@ -262,7 +277,7 @@ func (je patchEvent) Collection() string {
 }
 
 type patchEventJson struct {
-	Timestamp      int64         `json:"timestamp"`
+	Timestamp      interface{}   `json:"timestamp"`
 	ID             string        `json:"_id"`
 	CollectionName string        `json:"collection_name"`
 	Patch          operationJson `json:"patch"`

--- a/jsonpatcher/jsonpatcher_test.go
+++ b/jsonpatcher/jsonpatcher_test.go
@@ -1,0 +1,53 @@
+package jsonpatcher
+
+import (
+	"testing"
+	"time"
+
+	cbornode "github.com/ipfs/go-ipld-cbor"
+	mh "github.com/multiformats/go-multihash"
+	core "github.com/textileio/go-threads/core/db"
+)
+
+type patchEventOld struct {
+	Timestamp      time.Time
+	ID             core.InstanceID
+	CollectionName string
+	Patch          operation
+}
+
+func init() {
+	cbornode.RegisterCborType(patchEventOld{})
+	cbornode.RegisterCborType(time.Time{})
+}
+
+func TestJsonPatcher_Migration(t *testing.T) {
+	in1 := patchEventOld{Timestamp: time.Now(), ID: "123", CollectionName: "abc"}
+	node1, err := cbornode.WrapObject(in1, mh.SHA2_256, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := new(patchEvent)
+	err = cbornode.DecodeInto(node1.RawData(), &out)
+	if err != nil {
+		t.Errorf("failed to decode event with time.Time timestamp: %v", err)
+	}
+	if !out.time().Equal(time.Time{}) {
+		t.Error("non-encodable time should have zero-value")
+	}
+
+	ts := time.Now()
+	in2 := patchEvent{Timestamp: ts.UnixNano(), ID: "123", CollectionName: "abc"}
+	node2, err := cbornode.WrapObject(in2, mh.SHA2_256, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = cbornode.DecodeInto(node2.RawData(), &out)
+	if err != nil {
+		t.Errorf("failed to decode event with int64 timestamp: %v", err)
+	}
+	tsout := out.time()
+	if !tsout.Equal(ts) {
+		t.Error("encodable time should be equal to input")
+	}
+}

--- a/net/api/pb/javascript/package-lock.json
+++ b/net/api/pb/javascript/package-lock.json
@@ -28,9 +28,9 @@
       "integrity": "sha512-ZIf3qfLFayVrPvAjeKKxO5FRF1/NwRxt6Dko+fWEMuHwHbZx8/fcaAao9b0wCM6kr8qeg2te8XTpyuvKuD9aKw=="
     },
     "ts-protoc-gen": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/ts-protoc-gen/-/ts-protoc-gen-0.12.0.tgz",
-      "integrity": "sha512-V7jnICJxKqalBrnJSMTW5tB9sGi48gOC325bfcM7TDNUItVOlaMM//rQmuo49ybipk/SyJTnWXgtJnhHCevNJw==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/ts-protoc-gen/-/ts-protoc-gen-0.13.0.tgz",
+      "integrity": "sha512-j18X4rkDBbG/ZHUJy88WFeZP6mStGow5uREaohowlHXTu3/N7WcpyPhb7Vh6wN38ERmc/AkT9gqT98+vtlRhJA==",
       "dev": true,
       "requires": {
         "google-protobuf": "^3.6.1"

--- a/net/api/pb/javascript/package.json
+++ b/net/api/pb/javascript/package.json
@@ -20,6 +20,6 @@
     "google-protobuf": "^3.13.0"
   },
   "devDependencies": {
-    "ts-protoc-gen": "^0.12.0"
+    "ts-protoc-gen": "^0.13.0"
   }
 }


### PR DESCRIPTION
See https://github.com/textileio/go-threads/pull/416#discussion_r481080485

After trying a few different ways to fix this, I landed on just using `interface{}` for `Timestamp`, which allows us to continue bulk-decoding events with potentially mixed `Timestamp` types.