### PR TITLE
Local first optimizations

### DIFF
--- a/db/README.md
+++ b/db/README.md
@@ -98,7 +98,7 @@ with logical clocks.
 #### Dispatcher
 This is an internal component not available in the public API.
 Main responsibility: Source of truth regarding known `db.Event`s for the 
-`DB`. Will notify registered parties to let them know about new ones..
+`DB`. Will notify registered parties to let them know about new ones.
 
 Every `Event` generated in the `DB` is sent to a `Dispatcher` when write 
 transactions are committed. The dispatcher is responsible for broadcasting 

--- a/db/bench_test.go
+++ b/db/bench_test.go
@@ -135,7 +135,7 @@ func BenchmarkNoIndexSave(b *testing.B) {
 		if err != nil {
 			b.Fatalf("Error modifying instance: %s", err)
 		}
-		err = collection.Save(updated)
+		_, err = collection.Save(updated)
 		if err != nil {
 			b.Fatalf("Error creating instance: %s", err)
 		}
@@ -170,7 +170,7 @@ func BenchmarkIndexSave(b *testing.B) {
 		if err != nil {
 			b.Fatalf("Error modifying instance: %s", err)
 		}
-		err = collection.Save(updated)
+		_, err = collection.Save(updated)
 		if err != nil {
 			b.Fatalf("Error creating instance: %s", err)
 		}

--- a/db/bench_test.go
+++ b/db/bench_test.go
@@ -135,7 +135,7 @@ func BenchmarkNoIndexSave(b *testing.B) {
 		if err != nil {
 			b.Fatalf("Error modifying instance: %s", err)
 		}
-		_, err = collection.Save(updated)
+		err = collection.Save(updated)
 		if err != nil {
 			b.Fatalf("Error creating instance: %s", err)
 		}
@@ -170,7 +170,7 @@ func BenchmarkIndexSave(b *testing.B) {
 		if err != nil {
 			b.Fatalf("Error modifying instance: %s", err)
 		}
-		_, err = collection.Save(updated)
+		err = collection.Save(updated)
 		if err != nil {
 			b.Fatalf("Error creating instance: %s", err)
 		}

--- a/db/collection.go
+++ b/db/collection.go
@@ -210,28 +210,17 @@ func (c *Collection) DeleteMany(ids []core.InstanceID, opts ...TxnOption) error 
 }
 
 // Save saves changes of an instance in the collection.
-func (c *Collection) Save(v []byte, opts ...TxnOption) (id core.InstanceID, err error) {
-	err = c.WriteTxn(func(txn *Txn) error {
-		var ids []core.InstanceID
-		ids, err = txn.Save(v)
-		if err != nil {
-			return err
-		}
-		if len(ids) > 0 {
-			id = ids[0]
-		}
-		return nil
+func (c *Collection) Save(v []byte, opts ...TxnOption) error {
+	return c.WriteTxn(func(txn *Txn) error {
+		return txn.Save(v)
 	}, opts...)
-	return
 }
 
 // SaveMany saves changes of multiple instances in the collection.
-func (c *Collection) SaveMany(vs [][]byte, opts ...TxnOption) (ids []core.InstanceID, err error) {
-	err = c.WriteTxn(func(txn *Txn) error {
-		ids, err = txn.Save(vs...)
-		return err
+func (c *Collection) SaveMany(vs [][]byte, opts ...TxnOption) error {
+	return c.WriteTxn(func(txn *Txn) error {
+		return txn.Save(vs...)
 	}, opts...)
-	return
 }
 
 // Verify verifies changes of an instance in the collection.
@@ -524,22 +513,18 @@ func (t *Txn) Verify(updated ...[]byte) error {
 }
 
 // Save saves an instance changes to be committed when the current transaction commits.
-func (t *Txn) Save(updated ...[]byte) ([]core.InstanceID, error) {
+func (t *Txn) Save(updated ...[]byte) error {
 	identity, err := t.token.PubKey()
 	if err != nil {
-		return nil, err
+		return err
 	}
-	results := make([]core.InstanceID, len(updated))
 	actions, err := t.createSaveActions(identity, updated...)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	t.actions = append(t.actions, actions...)
-	for i, a := range actions {
-		results[i] = a.InstanceID
-	}
-	return results, nil
+	return nil
 }
 
 func (t *Txn) createSaveActions(identity thread.PubKey, updated ...[]byte) ([]core.Action, error) {

--- a/db/collection.go
+++ b/db/collection.go
@@ -210,17 +210,28 @@ func (c *Collection) DeleteMany(ids []core.InstanceID, opts ...TxnOption) error 
 }
 
 // Save saves changes of an instance in the collection.
-func (c *Collection) Save(v []byte, opts ...TxnOption) error {
-	return c.WriteTxn(func(txn *Txn) error {
-		return txn.Save(v)
+func (c *Collection) Save(v []byte, opts ...TxnOption) (id core.InstanceID, err error) {
+	err = c.WriteTxn(func(txn *Txn) error {
+		var ids []core.InstanceID
+		ids, err = txn.Save(v)
+		if err != nil {
+			return err
+		}
+		if len(ids) > 0 {
+			id = ids[0]
+		}
+		return nil
 	}, opts...)
+	return
 }
 
 // SaveMany saves changes of multiple instances in the collection.
-func (c *Collection) SaveMany(vs [][]byte, opts ...TxnOption) error {
-	return c.WriteTxn(func(txn *Txn) error {
-		return txn.Save(vs...)
+func (c *Collection) SaveMany(vs [][]byte, opts ...TxnOption) (ids []core.InstanceID, err error) {
+	err = c.WriteTxn(func(txn *Txn) error {
+		ids, err = txn.Save(vs...)
+		return err
 	}, opts...)
+	return
 }
 
 // Verify verifies changes of an instance in the collection.
@@ -513,17 +524,22 @@ func (t *Txn) Verify(updated ...[]byte) error {
 }
 
 // Save saves an instance changes to be committed when the current transaction commits.
-func (t *Txn) Save(updated ...[]byte) error {
+func (t *Txn) Save(updated ...[]byte) ([]core.InstanceID, error) {
 	identity, err := t.token.PubKey()
 	if err != nil {
-		return err
+		return nil, err
 	}
+	results := make([]core.InstanceID, len(updated))
 	actions, err := t.createSaveActions(identity, updated...)
 	if err != nil {
-		return err
+		return nil, err
 	}
+
 	t.actions = append(t.actions, actions...)
-	return nil
+	for i, a := range actions {
+		results[i] = a.InstanceID
+	}
+	return results, nil
 }
 
 func (t *Txn) createSaveActions(identity thread.PubKey, updated ...[]byte) ([]core.Action, error) {

--- a/db/collection.go
+++ b/db/collection.go
@@ -610,7 +610,8 @@ func (t *Txn) Delete(ids ...core.InstanceID) error {
 			return err
 		}
 		if !exists {
-			return ErrInstanceNotFound
+			// Nothing to be done here
+			return nil
 		}
 		a := core.Action{
 			Type:           core.Delete,

--- a/db/collection_test.go
+++ b/db/collection_test.go
@@ -132,12 +132,12 @@ func TestNewCollection(t *testing.T) {
 		checkErr(t, err)
 		dog.ID = id
 		dog.Name = "Bob"
-		err = c.Save(util.JSONFromInstance(dog))
+		_, err = c.Save(util.JSONFromInstance(dog))
 		if err == nil {
 			t.Fatal("save should have been invalid")
 		}
 		dog.Name = "Clyde"
-		err = c.Save(util.JSONFromInstance(dog))
+		_, err = c.Save(util.JSONFromInstance(dog))
 		checkErr(t, err)
 		err = c.Delete(dog.ID)
 		if err == nil {
@@ -696,7 +696,8 @@ func TestReadTxnValidation(t *testing.T) {
 		checkErr(t, err)
 		p = util.SetJSONID(res, p)
 		err = m.ReadTxn(func(txn *Txn) error {
-			return txn.Save(p)
+			_, err := txn.Save(p)
+			return err
 		})
 		if !errors.Is(err, ErrReadonlyTx) {
 			t.Fatal("shouldn't write on read-only transaction")
@@ -753,7 +754,8 @@ func TestVariadic(t *testing.T) {
 	pp2 := &Person{}
 	util.InstanceFromJSON(p2, pp2)
 	pp0.Age, pp1.Age, pp2.Age = 51, 52, 53
-	checkErr(t, m.SaveMany([][]byte{util.JSONFromInstance(pp0), util.JSONFromInstance(pp1), util.JSONFromInstance(pp2)}))
+	_, err = m.SaveMany([][]byte{util.JSONFromInstance(pp0), util.JSONFromInstance(pp1), util.JSONFromInstance(pp2)})
+	checkErr(t, err)
 	assertPersonInCollection(t, m, util.JSONFromInstance(pp0))
 	assertPersonInCollection(t, m, util.JSONFromInstance(pp1))
 	assertPersonInCollection(t, m, util.JSONFromInstance(pp2))
@@ -909,7 +911,7 @@ func TestModifiedSince(t *testing.T) {
 		// Save
 		newPerson = util.JSONFromInstance(Person{ID: res[0], Name: "Alice", Age: 51})
 		err = c.WriteTxn(func(txn *Txn) (err error) {
-			err = txn.Save(newPerson)
+			_, err = txn.Save(newPerson)
 			return
 		})
 		checkErr(t, err)
@@ -1043,7 +1045,8 @@ func TestSaveInstance(t *testing.T) {
 			util.InstanceFromJSON(instance, p)
 
 			p.Name = "Bob"
-			return txn.Save(util.JSONFromInstance(p))
+			_, err = txn.Save(util.JSONFromInstance(p))
+			return err
 		})
 		checkErr(t, err)
 
@@ -1070,7 +1073,7 @@ func TestSaveInstance(t *testing.T) {
 		checkErr(t, err)
 
 		p := util.JSONFromInstance(Person{Name: "Alice", Age: 42})
-		if err := m.Save(p); err != nil {
+		if _, err := m.Save(p); err != nil {
 			t.Fatal("should have saved non-existent instasnce")
 		}
 	})
@@ -1110,7 +1113,8 @@ func TestModTagIncrement(t *testing.T) {
 			}
 
 			p.Mod = 0 // Try to make it zero again
-			return txn.Save(util.JSONFromInstance(p))
+			_, err = txn.Save(util.JSONFromInstance(p))
+			return err
 		})
 		checkErr(t, err)
 
@@ -1211,7 +1215,7 @@ func TestInvalidActions(t *testing.T) {
 		_, err := c.Create(r)
 		checkErr(t, err)
 		f := util.JSONFromInstance(PersonFake{Name: "fake"})
-		if err := c.Save(f); !errors.Is(err, ErrInvalidSchemaInstance) {
+		if _, err := c.Save(f); !errors.Is(err, ErrInvalidSchemaInstance) {
 			t.Fatalf("instance should be invalid compared to schema, got: %v", err)
 		}
 	})

--- a/db/collection_test.go
+++ b/db/collection_test.go
@@ -132,12 +132,12 @@ func TestNewCollection(t *testing.T) {
 		checkErr(t, err)
 		dog.ID = id
 		dog.Name = "Bob"
-		_, err = c.Save(util.JSONFromInstance(dog))
+		err = c.Save(util.JSONFromInstance(dog))
 		if err == nil {
 			t.Fatal("save should have been invalid")
 		}
 		dog.Name = "Clyde"
-		_, err = c.Save(util.JSONFromInstance(dog))
+		err = c.Save(util.JSONFromInstance(dog))
 		checkErr(t, err)
 		err = c.Delete(dog.ID)
 		if err == nil {
@@ -696,8 +696,7 @@ func TestReadTxnValidation(t *testing.T) {
 		checkErr(t, err)
 		p = util.SetJSONID(res, p)
 		err = m.ReadTxn(func(txn *Txn) error {
-			_, err := txn.Save(p)
-			return err
+			return txn.Save(p)
 		})
 		if !errors.Is(err, ErrReadonlyTx) {
 			t.Fatal("shouldn't write on read-only transaction")
@@ -754,7 +753,7 @@ func TestVariadic(t *testing.T) {
 	pp2 := &Person{}
 	util.InstanceFromJSON(p2, pp2)
 	pp0.Age, pp1.Age, pp2.Age = 51, 52, 53
-	_, err = m.SaveMany([][]byte{util.JSONFromInstance(pp0), util.JSONFromInstance(pp1), util.JSONFromInstance(pp2)})
+	err = m.SaveMany([][]byte{util.JSONFromInstance(pp0), util.JSONFromInstance(pp1), util.JSONFromInstance(pp2)})
 	checkErr(t, err)
 	assertPersonInCollection(t, m, util.JSONFromInstance(pp0))
 	assertPersonInCollection(t, m, util.JSONFromInstance(pp1))
@@ -911,8 +910,7 @@ func TestModifiedSince(t *testing.T) {
 		// Save
 		newPerson = util.JSONFromInstance(Person{ID: res[0], Name: "Alice", Age: 51})
 		err = c.WriteTxn(func(txn *Txn) (err error) {
-			_, err = txn.Save(newPerson)
-			return
+			return txn.Save(newPerson)
 		})
 		checkErr(t, err)
 
@@ -1045,8 +1043,7 @@ func TestSaveInstance(t *testing.T) {
 			util.InstanceFromJSON(instance, p)
 
 			p.Name = "Bob"
-			_, err = txn.Save(util.JSONFromInstance(p))
-			return err
+			return txn.Save(util.JSONFromInstance(p))
 		})
 		checkErr(t, err)
 
@@ -1073,7 +1070,7 @@ func TestSaveInstance(t *testing.T) {
 		checkErr(t, err)
 
 		p := util.JSONFromInstance(Person{Name: "Alice", Age: 42})
-		if _, err := m.Save(p); err != nil {
+		if err := m.Save(p); err != nil {
 			t.Fatal("should have saved non-existent instasnce")
 		}
 	})
@@ -1113,8 +1110,7 @@ func TestModTagIncrement(t *testing.T) {
 			}
 
 			p.Mod = 0 // Try to make it zero again
-			_, err = txn.Save(util.JSONFromInstance(p))
-			return err
+			return txn.Save(util.JSONFromInstance(p))
 		})
 		checkErr(t, err)
 
@@ -1215,7 +1211,7 @@ func TestInvalidActions(t *testing.T) {
 		_, err := c.Create(r)
 		checkErr(t, err)
 		f := util.JSONFromInstance(PersonFake{Name: "fake"})
-		if _, err := c.Save(f); !errors.Is(err, ErrInvalidSchemaInstance) {
+		if err := c.Save(f); !errors.Is(err, ErrInvalidSchemaInstance) {
 			t.Fatalf("instance should be invalid compared to schema, got: %v", err)
 		}
 	})

--- a/db/collection_test.go
+++ b/db/collection_test.go
@@ -1181,8 +1181,8 @@ func TestDeleteInstance(t *testing.T) {
 	}
 
 	// Try to delete again
-	if err = c.Delete(res[0]); err != ErrInstanceNotFound {
-		t.Fatalf("cant't delete non-existent instance")
+	if err = c.Delete(res[0]); err != nil {
+		t.Fatalf("should be able to ignore deleting non-existent instances")
 	}
 }
 

--- a/db/db.go
+++ b/db/db.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/alecthomas/jsonschema"
 	"github.com/dop251/goja"
-	"github.com/ipfs/go-ipld-format"
+	format "github.com/ipfs/go-ipld-format"
 	logging "github.com/ipfs/go-log"
 	ma "github.com/multiformats/go-multiaddr"
 	ds "github.com/textileio/go-datastore"
@@ -31,6 +31,7 @@ import (
 
 const (
 	idFieldName                 = "_id"
+	modFieldName                = "_mod"
 	getBlockRetries             = 3
 	getBlockInitialTimeout      = time.Millisecond * 500
 	pullThreadBackgroundTimeout = time.Hour
@@ -43,7 +44,7 @@ var (
 	// ErrInvalidName indicates the provided name isn't valid for a Collection.
 	ErrInvalidName = errors.New("name may only contain alphanumeric characters or non-consecutive hyphens, and cannot begin or end with a hyphen")
 	// ErrInvalidCollectionSchema indicates the provided schema isn't valid for a Collection.
-	ErrInvalidCollectionSchema = errors.New("the collection schema should specify an _id string property")
+	ErrInvalidCollectionSchema = errors.New("the collection schema _id property must be a string")
 	// ErrCannotIndexIDField indicates a custom index was specified on the ID field.
 	ErrCannotIndexIDField = errors.New("cannot create custom index on " + idFieldName)
 
@@ -60,7 +61,7 @@ var (
 func init() {
 	nameRx = regexp.MustCompile(`^[A-Za-z0-9]+(?:[-][A-Za-z0-9]+)*$`)
 	// register empty map in order to gob-encode old-format events with non-encodable time.Time which cbor decodes as map[string]interface{}
-	gob.Register(map[string]interface {}{})
+	gob.Register(map[string]interface{}{})
 }
 
 // DB is the aggregate-root of events and state. External/remote events

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -47,7 +47,7 @@ func TestE2EWithThreads(t *testing.T) {
 	checkErr(t, err)
 	dummyJSON = util.SetJSONID(res, dummyJSON)
 	dummyJSON = util.SetJSONProperty("Counter", 42, dummyJSON)
-	_, err = c1.Save(dummyJSON)
+	err = c1.Save(dummyJSON)
 	checkErr(t, err)
 
 	// Make sure the thread can't be deleted directly
@@ -367,7 +367,7 @@ func runListenersComplexUseCase(t *testing.T, los ...ListenOption) []Action {
 
 	// Collection1 Save i1
 	i1 = util.SetJSONProperty("Name", "Textile0", i1)
-	_, err = c1.Save(i1)
+	err = c1.Save(i1)
 	checkErr(t, err)
 
 	// Collection1 Create i2
@@ -385,15 +385,14 @@ func runListenersComplexUseCase(t *testing.T, los ...ListenOption) []Action {
 	err = c1.WriteTxn(func(txn *Txn) error {
 		i1 = util.SetJSONProperty("Counter", 30, i1)
 		i2 = util.SetJSONProperty("Counter", 11, i2)
-		_, err = txn.Save(i1, i2)
-		return err
+		return txn.Save(i1, i2)
 	})
 	checkErr(t, err)
 
 	// Collection2 Save j1
 	j1 = util.SetJSONProperty("Counter", -1, j1)
 	j1 = util.SetJSONProperty("Name", "Textile33", j1)
-	_, err = c2.Save(j1)
+	err = c2.Save(j1)
 	checkErr(t, err)
 
 	checkErr(t, c1.Delete(i1Ids))

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ipfs/go-ipld-format"
+	format "github.com/ipfs/go-ipld-format"
 	"github.com/multiformats/go-multiaddr"
 	ds "github.com/textileio/go-datastore"
 	"github.com/textileio/go-threads/common"
@@ -47,7 +47,8 @@ func TestE2EWithThreads(t *testing.T) {
 	checkErr(t, err)
 	dummyJSON = util.SetJSONID(res, dummyJSON)
 	dummyJSON = util.SetJSONProperty("Counter", 42, dummyJSON)
-	checkErr(t, c1.Save(dummyJSON))
+	_, err = c1.Save(dummyJSON)
+	checkErr(t, err)
 
 	// Make sure the thread can't be deleted directly
 	err = n1.DeleteThread(context.Background(), id1)
@@ -366,7 +367,8 @@ func runListenersComplexUseCase(t *testing.T, los ...ListenOption) []Action {
 
 	// Collection1 Save i1
 	i1 = util.SetJSONProperty("Name", "Textile0", i1)
-	checkErr(t, c1.Save(i1))
+	_, err = c1.Save(i1)
+	checkErr(t, err)
 
 	// Collection1 Create i2
 	i2 := util.JSONFromInstance(dummy{ID: "id-i2", Name: "Textile2"})
@@ -383,14 +385,16 @@ func runListenersComplexUseCase(t *testing.T, los ...ListenOption) []Action {
 	err = c1.WriteTxn(func(txn *Txn) error {
 		i1 = util.SetJSONProperty("Counter", 30, i1)
 		i2 = util.SetJSONProperty("Counter", 11, i2)
-		return txn.Save(i1, i2)
+		_, err = txn.Save(i1, i2)
+		return err
 	})
 	checkErr(t, err)
 
 	// Collection2 Save j1
 	j1 = util.SetJSONProperty("Counter", -1, j1)
 	j1 = util.SetJSONProperty("Name", "Textile33", j1)
-	checkErr(t, c2.Save(j1))
+	_, err = c2.Save(j1)
+	checkErr(t, err)
 
 	checkErr(t, c1.Delete(i1Ids))
 

--- a/db/dispatcher.go
+++ b/db/dispatcher.go
@@ -43,8 +43,12 @@ func newDispatcher(store datastore.TxnDatastore) *dispatcher {
 }
 
 // Store returns the internal event store.
-func (d *dispatcher) Store() datastore.Datastore {
+func (d *dispatcher) Store() datastore.TxnDatastore {
 	return d.store
+}
+
+func (d *dispatcher) Lock() *sync.RWMutex {
+	return &d.lock
 }
 
 // Register takes a reducer to be invoked with each dispatched event.
@@ -122,7 +126,8 @@ func getKey(event core.Event) (key datastore.Key, err error) {
 	}
 	time := strconv.FormatInt(unix, 10)
 	key = dsDispatcherPrefix.ChildString(time).
-		ChildString(event.InstanceID().String()).
-		ChildString(event.Collection())
+		ChildString(event.Collection()).
+		Instance(event.InstanceID().String())
+
 	return key, nil
 }


### PR DESCRIPTION
This PR contains a few small nits and optimizations that make building on offline-first client for ThreadDB easier. The main changes are that a call to Save can now also lead to a Create action being generated if and only if the call to Save includes an existing Instance ID as a simple safety check. This allows callers to write or overwrite an existing Instance, without having to check first if it already exists. An additional change is that Delete now silently ignores missing Instances. This means a client can call delete on an Instance that might have already been deleted while it was offline or similar, without throwing an error.

Finally, the more important addition is the "special" _mod field. This is simple a "readonly" timestamp that gets added to all Instances. Any changes to this field will be ignored by the peer, and will be automatically updated on Save (and initialized on Create). This doesn't really have any effect on Delete, which is partly why the ModifiedSince experimental API was also created.