### PR TITLE
Balanced thread pulling

### DIFF
--- a/integrationtests/foldersync/foldersync_test.go
+++ b/integrationtests/foldersync/foldersync_test.go
@@ -149,7 +149,7 @@ func TestNUsersBootstrap(t *testing.T) {
 		randFileSize     int
 		checkSyncedFiles bool
 	}{
-		{totalClients: 2, totalCorePeers: 1, syncTimeout: time.Second * 10},
+		{totalClients: 2, totalCorePeers: 1, syncTimeout: time.Second * 15},
 		{totalClients: 3, totalCorePeers: 1, syncTimeout: time.Second * 30},
 
 		{totalClients: 3, totalCorePeers: 2, syncTimeout: time.Second * 30},

--- a/net/api/client/client_test.go
+++ b/net/api/client/client_test.go
@@ -364,7 +364,7 @@ func TestClient_Subscribe(t *testing.T) {
 		if _, err = client1.CreateRecord(context.Background(), info.ID, body2); err != nil {
 			t.Fatal(err)
 		}
-		time.Sleep(time.Second * 2)
+		time.Sleep(time.Second * 10)
 
 		lock.Lock()
 		if rcount != 2 {

--- a/net/net.go
+++ b/net/net.go
@@ -39,7 +39,10 @@ var (
 	// MaxPullLimit is the maximum page size for pulling records.
 	MaxPullLimit = 10000
 
-	// InitialPullInterval is the interval between automatic log pulls.
+	// PullStartAfter is the pause before thread pulling process starts.
+	PullStartAfter = time.Second
+
+	// InitialPullInterval is the interval for the first iteration of log pulls.
 	InitialPullInterval = time.Second
 
 	// PullInterval is the interval between automatic log pulls.
@@ -1139,10 +1142,14 @@ func (n *net) deleteRecord(ctx context.Context, rid cid.Cid, sk *sym.Key) (prev 
 // startPulling periodically pulls on all threads.
 func (n *net) startPulling() {
 	select {
-	case <-time.After(InitialPullInterval):
+	case <-time.After(PullStartAfter):
 	case <-n.ctx.Done():
 		return
 	}
+
+	// set pull cycle interval into initial value,
+	// it will be redefined on the next iteration
+	var interval = InitialPullInterval
 
 PullCycle:
 	for {
@@ -1155,7 +1162,8 @@ PullCycle:
 		if len(ts) == 0 {
 			// if there are no threads served, just wait and retry
 			select {
-			case <-time.After(PullInterval):
+			case <-time.After(interval):
+				interval = PullInterval
 				continue PullCycle
 			case <-n.ctx.Done():
 				return
@@ -1163,7 +1171,7 @@ PullCycle:
 		}
 
 		var (
-			period = PullInterval / time.Duration(len(ts))
+			period = interval / time.Duration(len(ts))
 			ticker = time.NewTicker(period)
 			idx    = 0
 		)
@@ -1179,6 +1187,7 @@ PullCycle:
 				idx++
 				if idx >= len(ts) {
 					ticker.Stop()
+					interval = PullInterval
 					continue PullCycle
 				}
 


### PR DESCRIPTION
Here is a small improvement essential for the ThreadsDB nodes serving a lot of threads. Currently threads are pulled as follows: once in a period goroutines with `pullThread` procedure for all known threads start simultaneously, and it leads to substantial spikes in CPU/memory/network usage. We can pretty easily get rid of the spikes and equalize resource consumption by allocating pull operations evenly during the specified period.
![balanced-pulling](https://user-images.githubusercontent.com/7447516/95998408-7f82bb00-0e3d-11eb-9221-e292bdc27a05.png)
