### PR TITLE
Better behavior when saving non-existent instance

### DIFF
--- a/jsonpatcher/jsonpatcher.go
+++ b/jsonpatcher/jsonpatcher.go
@@ -11,7 +11,7 @@ import (
 
 	jsonpatch "github.com/evanphx/json-patch"
 	cbornode "github.com/ipfs/go-ipld-cbor"
-	"github.com/ipfs/go-ipld-format"
+	format "github.com/ipfs/go-ipld-format"
 	logging "github.com/ipfs/go-log"
 	"github.com/multiformats/go-multihash"
 	ds "github.com/textileio/go-datastore"
@@ -149,9 +149,8 @@ func (jp *jsonPatcher) Reduce(events []core.Event, datastore ds.TxnDatastore, ba
 		case save:
 			value, err := txn.Get(key)
 			if errors.Is(err, ds.ErrNotFound) {
-				return nil, errSavingNonExistentInstance
-			}
-			if err != nil {
+				value = []byte("{}")
+			} else if err != nil {
 				return nil, err
 			}
 			patchedValue, err := jsonpatch.MergePatch(value, je.Patch.JSONPatch)


### PR DESCRIPTION
This PR fixes a "regression" introduced with the new Save behavior introduced with #450. It also adds a test that should catch this in the future. The issue is that our transactions don't currently provide isolation guarantees, which is particularly problematic when doing remote updates in batches. To get around this, we provide default behavior for "Saving" a non-existent instance. However, we still had an additional check on the patcher that wasn't allowing this. This now allows saves on non-existent instances, but also simplifies the logic on the collection so we aren't special casing this anymore.