### PR TITLE
Hybrid logstore

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -92,7 +92,7 @@ func DefaultNetwork(repoPath string, opts ...NetOption) (NetBoostrapper, error) 
 		return nil, fin.Cleanup(err)
 	}
 
-	tstore, err := buildLogstore(ctx, config.LogstoreKind, repoPath, fin)
+	tstore, err := buildLogstore(ctx, config.LSType, repoPath, fin)
 	if err != nil {
 		return nil, fin.Cleanup(err)
 	}
@@ -114,8 +114,8 @@ func DefaultNetwork(repoPath string, opts ...NetOption) (NetBoostrapper, error) 
 	}, nil
 }
 
-func buildLogstore(ctx context.Context, kind LogstoreKind, repoPath string, fin *util.Finalizer) (core.Logstore, error) {
-	switch kind {
+func buildLogstore(ctx context.Context, lstype LogstoreType, repoPath string, fin *util.Finalizer) (core.Logstore, error) {
+	switch lstype {
 	case LogstoreInMemory:
 		return lstoremem.NewLogstore(), nil
 
@@ -131,7 +131,7 @@ func buildLogstore(ctx context.Context, kind LogstoreKind, repoPath string, fin 
 		return persistentLogstore(ctx, repoPath, fin)
 
 	default:
-		return nil, fmt.Errorf("unsupported kind of logstore: %s", kind)
+		return nil, fmt.Errorf("unsupported logstore type: %s", lstype)
 	}
 }
 
@@ -163,19 +163,19 @@ func setDefaults(config *NetConfig) error {
 		config.ConnManager = connmgr.NewConnManager(100, 400, time.Second*20)
 	}
 
-	if len(config.LogstoreKind) == 0 {
-		config.LogstoreKind = LogstorePersistent
+	if len(config.LSType) == 0 {
+		config.LSType = LogstorePersistent
 	}
 
 	return nil
 }
 
-type LogstoreKind string
+type LogstoreType string
 
 const (
-	LogstoreInMemory   LogstoreKind = "in-memory"
-	LogstorePersistent LogstoreKind = "persistent"
-	LogstoreHybrid     LogstoreKind = "hybrid"
+	LogstoreInMemory   LogstoreType = "in-memory"
+	LogstorePersistent LogstoreType = "persistent"
+	LogstoreHybrid     LogstoreType = "hybrid"
 )
 
 type NetConfig struct {
@@ -183,7 +183,7 @@ type NetConfig struct {
 	ConnManager       cconnmgr.ConnManager
 	GRPCServerOptions []grpc.ServerOption
 	GRPCDialOptions   []grpc.DialOption
-	LogstoreKind      LogstoreKind
+	LSType            LogstoreType
 	PubSub            bool
 	Debug             bool
 }
@@ -232,9 +232,9 @@ func WithNetPubSub(enabled bool) NetOption {
 	}
 }
 
-func WithNetLogstore(lk LogstoreKind) NetOption {
+func WithNetLogstore(lt LogstoreType) NetOption {
 	return func(c *NetConfig) error {
-		c.LogstoreKind = lk
+		c.LSType = lt
 		return nil
 	}
 }

--- a/common/common.go
+++ b/common/common.go
@@ -2,25 +2,25 @@ package common
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
 
 	ipfslite "github.com/hsanjuan/ipfs-lite"
-	datastore "github.com/ipfs/go-datastore"
 	"github.com/libp2p/go-libp2p"
 	connmgr "github.com/libp2p/go-libp2p-connmgr"
 	cconnmgr "github.com/libp2p/go-libp2p-core/connmgr"
-	host "github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
-	peerstore "github.com/libp2p/go-libp2p-core/peerstore"
-	"github.com/libp2p/go-libp2p-kad-dht/dual"
 	"github.com/libp2p/go-libp2p-peerstore/pstoreds"
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/textileio/go-threads/core/app"
+	core "github.com/textileio/go-threads/core/logstore"
 	"github.com/textileio/go-threads/logstore/lstoreds"
+	"github.com/textileio/go-threads/logstore/lstorehybrid"
+	"github.com/textileio/go-threads/logstore/lstoremem"
 	"github.com/textileio/go-threads/net"
-	util "github.com/textileio/go-threads/util"
+	"github.com/textileio/go-threads/util"
 	"google.golang.org/grpc"
 )
 
@@ -37,41 +37,41 @@ type NetBoostrapper interface {
 }
 
 func DefaultNetwork(repoPath string, opts ...NetOption) (NetBoostrapper, error) {
-	config := &NetConfig{}
+	var (
+		config NetConfig
+		fin    = util.NewFinalizer()
+	)
+
 	for _, opt := range opts {
-		if err := opt(config); err != nil {
+		if err := opt(&config); err != nil {
 			return nil, err
 		}
 	}
 
-	if config.HostAddr == nil {
-		addr, err := ma.NewMultiaddr("/ip4/0.0.0.0/tcp/0")
-		if err != nil {
-			return nil, err
-		}
-		config.HostAddr = addr
-	}
-
-	if config.ConnManager == nil {
-		config.ConnManager = connmgr.NewConnManager(100, 400, time.Second*20)
+	if err := setDefaults(&config); err != nil {
+		return nil, err
 	}
 
 	ipfsLitePath := filepath.Join(repoPath, defaultIpfsLitePath)
 	if err := os.MkdirAll(ipfsLitePath, os.ModePerm); err != nil {
 		return nil, err
 	}
+
 	litestore, err := ipfslite.BadgerDatastore(ipfsLitePath)
 	if err != nil {
 		return nil, err
 	}
+	fin.Add(litestore)
 
 	ctx, cancel := context.WithCancel(context.Background())
+	fin.Add(util.NewContextCloser(cancel))
+
 	pstore, err := pstoreds.NewPeerstore(ctx, litestore, pstoreds.DefaultOpts())
 	if err != nil {
-		litestore.Close()
-		cancel()
-		return nil, err
+		return nil, fin.Cleanup(err)
 	}
+	fin.Add(pstore)
+
 	priv := util.LoadKey(filepath.Join(ipfsLitePath, "key"))
 	h, d, err := ipfslite.SetupLibp2p(
 		ctx,
@@ -84,37 +84,17 @@ func DefaultNetwork(repoPath string, opts ...NetOption) (NetBoostrapper, error) 
 		libp2p.DisableRelay(),
 	)
 	if err != nil {
-		cancel()
-		litestore.Close()
-		return nil, err
-	}
-	lite, err := ipfslite.New(ctx, litestore, h, d, nil)
-	if err != nil {
-		cancel()
-		litestore.Close()
-		return nil, err
+		return nil, fin.Cleanup(err)
 	}
 
-	// Build a logstore
-	logstorePath := filepath.Join(repoPath, defaultLogstorePath)
-	if err := os.MkdirAll(logstorePath, os.ModePerm); err != nil {
-		cancel()
-		return nil, err
-	}
-	logstore, err := ipfslite.BadgerDatastore(logstorePath)
+	lite, err := ipfslite.New(ctx, litestore, h, d, nil)
 	if err != nil {
-		cancel()
-		litestore.Close()
-		return nil, err
+		return nil, fin.Cleanup(err)
 	}
-	tstore, err := lstoreds.NewLogstore(ctx, logstore, lstoreds.DefaultOpts())
+
+	tstore, err := buildLogstore(ctx, config.LogstoreKind, repoPath, fin)
 	if err != nil {
-		cancel()
-		if err := logstore.Close(); err != nil {
-			return nil, err
-		}
-		litestore.Close()
-		return nil, err
+		return nil, fin.Cleanup(err)
 	}
 
 	// Build a network
@@ -123,33 +103,89 @@ func DefaultNetwork(repoPath string, opts ...NetOption) (NetBoostrapper, error) 
 		PubSub: config.PubSub,
 	}, config.GRPCServerOptions, config.GRPCDialOptions)
 	if err != nil {
-		cancel()
-		if err := logstore.Close(); err != nil {
+		return nil, fin.Cleanup(err)
+	}
+	fin.Add(h, d, api)
+
+	return &netBoostrapper{
+		Net:       api,
+		litepeer:  lite,
+		finalizer: fin,
+	}, nil
+}
+
+func buildLogstore(ctx context.Context, kind LogstoreKind, repoPath string, fin *util.Finalizer) (core.Logstore, error) {
+	switch kind {
+	case LogstoreInMemory:
+		return lstoremem.NewLogstore(), nil
+
+	case LogstoreHybrid:
+		pls, err := persistentLogstore(ctx, repoPath, fin)
+		if err != nil {
 			return nil, err
 		}
-		litestore.Close()
+		mls := lstoremem.NewLogstore()
+		return lstorehybrid.NewLogstore(pls, mls)
+
+	case LogstorePersistent:
+		return persistentLogstore(ctx, repoPath, fin)
+
+	default:
+		return nil, fmt.Errorf("unsupported kind of logstore: %s", kind)
+	}
+}
+
+func persistentLogstore(ctx context.Context, repoPath string, fin *util.Finalizer) (core.Logstore, error) {
+	logstorePath := filepath.Join(repoPath, defaultLogstorePath)
+	if err := os.MkdirAll(logstorePath, os.ModePerm); err != nil {
 		return nil, err
 	}
 
-	return &netBoostrapper{
-		cancel:    cancel,
-		Net:       api,
-		litepeer:  lite,
-		pstore:    pstore,
-		logstore:  logstore,
-		litestore: litestore,
-		host:      h,
-		dht:       d,
-	}, nil
+	dstore, err := ipfslite.BadgerDatastore(logstorePath)
+	if err != nil {
+		return nil, err
+	}
+	fin.Add(dstore)
+
+	return lstoreds.NewLogstore(ctx, dstore, lstoreds.DefaultOpts())
 }
+
+func setDefaults(config *NetConfig) error {
+	if config.HostAddr == nil {
+		addr, err := ma.NewMultiaddr("/ip4/0.0.0.0/tcp/0")
+		if err != nil {
+			return err
+		}
+		config.HostAddr = addr
+	}
+
+	if config.ConnManager == nil {
+		config.ConnManager = connmgr.NewConnManager(100, 400, time.Second*20)
+	}
+
+	if len(config.LogstoreKind) == 0 {
+		config.LogstoreKind = LogstorePersistent
+	}
+
+	return nil
+}
+
+type LogstoreKind string
+
+const (
+	LogstoreInMemory   LogstoreKind = "in-memory"
+	LogstorePersistent LogstoreKind = "persistent"
+	LogstoreHybrid     LogstoreKind = "hybrid"
+)
 
 type NetConfig struct {
 	HostAddr          ma.Multiaddr
 	ConnManager       cconnmgr.ConnManager
-	Debug             bool
 	GRPCServerOptions []grpc.ServerOption
 	GRPCDialOptions   []grpc.DialOption
+	LogstoreKind      LogstoreKind
 	PubSub            bool
+	Debug             bool
 }
 
 type NetOption func(c *NetConfig) error
@@ -196,15 +232,17 @@ func WithNetPubSub(enabled bool) NetOption {
 	}
 }
 
+func WithNetLogstore(lk LogstoreKind) NetOption {
+	return func(c *NetConfig) error {
+		c.LogstoreKind = lk
+		return nil
+	}
+}
+
 type netBoostrapper struct {
-	cancel context.CancelFunc
 	app.Net
 	litepeer  *ipfslite.Peer
-	pstore    peerstore.Peerstore
-	logstore  datastore.Datastore
-	litestore datastore.Datastore
-	host      host.Host
-	dht       *dual.DHT
+	finalizer *util.Finalizer
 }
 
 var _ NetBoostrapper = (*netBoostrapper)(nil)
@@ -218,22 +256,5 @@ func (tsb *netBoostrapper) GetIpfsLite() *ipfslite.Peer {
 }
 
 func (tsb *netBoostrapper) Close() error {
-	if err := tsb.Net.Close(); err != nil {
-		return err
-	}
-	tsb.cancel()
-	if err := tsb.dht.Close(); err != nil {
-		return err
-	}
-	if err := tsb.host.Close(); err != nil {
-		return err
-	}
-	if err := tsb.pstore.Close(); err != nil {
-		return err
-	}
-	if err := tsb.litestore.Close(); err != nil {
-		return err
-	}
-	return tsb.logstore.Close()
-	// Logstore closed by network
+	return tsb.finalizer.Cleanup(nil)
 }

--- a/core/logstore/logstore.go
+++ b/core/logstore/logstore.go
@@ -2,6 +2,7 @@ package logstore
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -24,6 +25,9 @@ var ErrLogNotFound = fmt.Errorf("log not found")
 
 // ErrLogExists indicates a requested log already exists.
 var ErrLogExists = fmt.Errorf("log already exists")
+
+// ErrEmptyDump indicates an attempt to restore from empty dump.
+var ErrEmptyDump = errors.New("empty dump")
 
 // Logstore stores log keys, addresses, heads and thread meta data.
 type Logstore interface {

--- a/core/logstore/logstore.go
+++ b/core/logstore/logstore.go
@@ -91,6 +91,12 @@ type ThreadMetadata interface {
 
 	// ClearMetadata clears all metadata under a thread.
 	ClearMetadata(t thread.ID) error
+
+	// DumpMeta packs all the stored metadata.
+	DumpMeta() (DumpMetadata, error)
+
+	// RestoreMeta restores metadata from the dump.
+	RestoreMeta(book DumpMetadata) error
 }
 
 // KeyBook stores log keys.
@@ -224,6 +230,20 @@ type (
 			Private map[thread.ID]map[peer.ID]crypto.PrivKey
 			Read    map[thread.ID][]byte
 			Service map[thread.ID][]byte
+		}
+	}
+
+	MetadataKey struct {
+		T thread.ID
+		K string
+	}
+
+	DumpMetadata struct {
+		Data struct {
+			Int64  map[MetadataKey]int64
+			Bool   map[MetadataKey]bool
+			String map[MetadataKey]string
+			Bytes  map[MetadataKey][]byte
 		}
 	}
 )

--- a/core/logstore/logstore.go
+++ b/core/logstore/logstore.go
@@ -130,6 +130,12 @@ type KeyBook interface {
 
 	// ThreadsFromKeys returns a list of threads referenced in the book.
 	ThreadsFromKeys() (thread.IDSlice, error)
+
+	// DumpKeys packs all stored keys.
+	DumpKeys() (DumpKeyBook, error)
+
+	// RestoreKeys restores keys from the dump.
+	RestoreKeys(book DumpKeyBook) error
 }
 
 // AddrBook stores log addresses.
@@ -210,5 +216,14 @@ type (
 
 	DumpAddrBook struct {
 		Data map[thread.ID]map[peer.ID][]ExpiredAddress
+	}
+
+	DumpKeyBook struct {
+		Data struct {
+			Public  map[thread.ID]map[peer.ID]crypto.PubKey
+			Private map[thread.ID]map[peer.ID]crypto.PrivKey
+			Read    map[thread.ID][]byte
+			Service map[thread.ID][]byte
+		}
 	}
 )

--- a/core/logstore/logstore.go
+++ b/core/logstore/logstore.go
@@ -180,4 +180,17 @@ type HeadBook interface {
 
 	// ClearHeads deletes the head entry for a log.
 	ClearHeads(thread.ID, peer.ID) error
+
+	// DumpHeads packs entire headbook into the tree.
+	DumpHeads() (DumpHeadBook, error)
+
+	// RestoreHeads restores headbook from the dump.
+	RestoreHeads(DumpHeadBook) error
 }
+
+type (
+	DumpHeadBook struct {
+		Data map[thread.ID]map[peer.ID][]cid.Cid
+	}
+)
+

--- a/core/logstore/logstore.go
+++ b/core/logstore/logstore.go
@@ -159,6 +159,12 @@ type AddrBook interface {
 
 	// ThreadsFromAddrs returns a list of threads referenced in the book.
 	ThreadsFromAddrs() (thread.IDSlice, error)
+
+	// DumpHeads packs all stored addresses.
+	DumpAddrs() (DumpAddrBook, error)
+
+	// RestoreHeads restores addresses from the dump.
+	RestoreAddrs(book DumpAddrBook) error
 }
 
 // HeadBook stores log heads.
@@ -192,5 +198,13 @@ type (
 	DumpHeadBook struct {
 		Data map[thread.ID]map[peer.ID][]cid.Cid
 	}
-)
 
+	ExpiredAddress struct {
+		Addr    ma.Multiaddr
+		Expires time.Time
+	}
+
+	DumpAddrBook struct {
+		Data map[thread.ID]map[peer.ID][]ExpiredAddress
+	}
+)

--- a/go.mod
+++ b/go.mod
@@ -41,8 +41,10 @@ require (
 	github.com/libp2p/go-libp2p v0.10.3
 	github.com/libp2p/go-libp2p-connmgr v0.2.4
 	github.com/libp2p/go-libp2p-core v0.6.1
+	github.com/libp2p/go-libp2p-crypto v0.1.0
 	github.com/libp2p/go-libp2p-gostream v0.2.0
 	github.com/libp2p/go-libp2p-kad-dht v0.8.3
+	github.com/libp2p/go-libp2p-peer v0.2.0
 	github.com/libp2p/go-libp2p-peerstore v0.2.6
 	github.com/libp2p/go-libp2p-pubsub v0.2.4
 	github.com/libp2p/go-libp2p-swarm v0.2.8

--- a/logstore/logstore.go
+++ b/logstore/logstore.go
@@ -12,6 +12,8 @@ import (
 	"github.com/textileio/go-threads/core/thread"
 )
 
+var _ core.Logstore = (*logstore)(nil)
+
 var managedSuffix = "/managed"
 
 // logstore is a collection of books for storing thread logs.

--- a/logstore/lstoreds/addr_book.go
+++ b/logstore/lstoreds/addr_book.go
@@ -2,6 +2,7 @@ package lstoreds
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -477,7 +478,7 @@ func (ab *DsAddrBook) DumpAddrs() (logstore.DumpAddrBook, error) {
 					var r = rec.Addrs[i]
 					addrs[i] = logstore.ExpiredAddress{
 						Addr:    r.Addr,
-						Expires: time.Unix(0, r.Expiry),
+						Expires: time.Unix(r.Expiry, 0),
 					}
 				}
 				lm[lid] = addrs
@@ -490,6 +491,10 @@ func (ab *DsAddrBook) DumpAddrs() (logstore.DumpAddrBook, error) {
 }
 
 func (ab *DsAddrBook) RestoreAddrs(dump logstore.DumpAddrBook) error {
+	if len(dump.Data) == 0 {
+		return errors.New("empty dump")
+	}
+
 	// avoid interference with garbage collection
 	ab.gc.running <- struct{}{}
 	defer func() { <-ab.gc.running }()

--- a/logstore/lstoreds/addr_book.go
+++ b/logstore/lstoreds/addr_book.go
@@ -2,7 +2,6 @@ package lstoreds
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -492,7 +491,7 @@ func (ab *DsAddrBook) DumpAddrs() (logstore.DumpAddrBook, error) {
 
 func (ab *DsAddrBook) RestoreAddrs(dump logstore.DumpAddrBook) error {
 	if len(dump.Data) == 0 {
-		return errors.New("empty dump")
+		return logstore.ErrEmptyDump
 	}
 
 	// avoid interference with garbage collection

--- a/logstore/lstoreds/addr_book.go
+++ b/logstore/lstoreds/addr_book.go
@@ -545,15 +545,13 @@ func (ab *DsAddrBook) traverse(withAddrs bool) (map[thread.ID]map[peer.ID]*pb.Ad
 		ts, ls := kns[len(kns)-2], kns[len(kns)-1]
 
 		// parse thread ID
-		pid, _ := base32.RawStdEncoding.DecodeString(ts)
-		tid, err := thread.Cast(pid)
+		tid, err := parseThreadID(ts)
 		if err != nil {
 			return nil, fmt.Errorf("cannot restore thread ID %s: %w", ts, err)
 		}
 
 		// parse log ID
-		pid, _ = base32.RawStdEncoding.DecodeString(ls)
-		lid, err := peer.IDFromBytes(pid)
+		lid, err := parseLogID(ls)
 		if err != nil {
 			return nil, fmt.Errorf("cannot restore log ID %s: %w", ls, err)
 		}

--- a/logstore/lstoreds/addr_book.go
+++ b/logstore/lstoreds/addr_book.go
@@ -533,6 +533,7 @@ func (ab *DsAddrBook) traverse(withAddrs bool) (map[thread.ID]map[peer.ID]*pb.Ad
 	if err != nil {
 		return nil, err
 	}
+	defer result.Close()
 
 	for entry := range result.Next() {
 		kns := ds.RawKey(entry.Key).Namespaces()

--- a/logstore/lstoreds/addr_book.go
+++ b/logstore/lstoreds/addr_book.go
@@ -490,7 +490,7 @@ func (ab *DsAddrBook) DumpAddrs() (logstore.DumpAddrBook, error) {
 }
 
 func (ab *DsAddrBook) RestoreAddrs(dump logstore.DumpAddrBook) error {
-	if len(dump.Data) == 0 {
+	if !AllowEmptyRestore && len(dump.Data) == 0 {
 		return logstore.ErrEmptyDump
 	}
 

--- a/logstore/lstoreds/headbook.go
+++ b/logstore/lstoreds/headbook.go
@@ -1,7 +1,6 @@
 package lstoreds
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/gogo/protobuf/proto"
@@ -145,7 +144,7 @@ func (hb *dsHeadBook) DumpHeads() (core.DumpHeadBook, error) {
 // Not a thread-safe, should not be interleaved with other methods!
 func (hb *dsHeadBook) RestoreHeads(dump core.DumpHeadBook) error {
 	if len(dump.Data) == 0 {
-		return errors.New("empty dump")
+		return core.ErrEmptyDump
 	}
 
 	stored, err := hb.traverse(false)

--- a/logstore/lstoreds/headbook.go
+++ b/logstore/lstoreds/headbook.go
@@ -143,7 +143,7 @@ func (hb *dsHeadBook) DumpHeads() (core.DumpHeadBook, error) {
 // Restore headbook from the provided dump replacing all the local data.
 // Not a thread-safe, should not be interleaved with other methods!
 func (hb *dsHeadBook) RestoreHeads(dump core.DumpHeadBook) error {
-	if len(dump.Data) == 0 {
+	if !AllowEmptyRestore && len(dump.Data) == 0 {
 		return core.ErrEmptyDump
 	}
 

--- a/logstore/lstoreds/headbook.go
+++ b/logstore/lstoreds/headbook.go
@@ -1,6 +1,7 @@
 package lstoreds
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/gogo/protobuf/proto"
@@ -144,6 +145,10 @@ func (hb *dsHeadBook) DumpHeads() (core.DumpHeadBook, error) {
 // Restore headbook from the provided dump replacing all the local data.
 // Not a thread-safe, should not be interleaved with other methods!
 func (hb *dsHeadBook) RestoreHeads(dump core.DumpHeadBook) error {
+	if len(dump.Data) == 0 {
+		return errors.New("empty dump")
+	}
+
 	stored, err := hb.traverse(false)
 	if err != nil {
 		return fmt.Errorf("traversing datastore: %w", err)

--- a/logstore/lstoreds/headbook.go
+++ b/logstore/lstoreds/headbook.go
@@ -179,6 +179,7 @@ func (hb *dsHeadBook) traverse(withHeads bool) (map[thread.ID]map[peer.ID][]cid.
 	if err != nil {
 		return nil, err
 	}
+	defer result.Close()
 
 	for entry := range result.Next() {
 		kns := ds.RawKey(entry.Key).Namespaces()

--- a/logstore/lstoreds/headbook.go
+++ b/logstore/lstoreds/headbook.go
@@ -1,15 +1,20 @@
 package lstoreds
 
 import (
+	"encoding/gob"
 	"fmt"
+	"io"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/ipfs/go-cid"
 	ds "github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/query"
 	"github.com/libp2p/go-libp2p-core/peer"
 	core "github.com/textileio/go-threads/core/logstore"
 	"github.com/textileio/go-threads/core/thread"
+	"github.com/textileio/go-threads/logstore"
 	pb "github.com/textileio/go-threads/net/pb"
+	"github.com/whyrusleeping/base32"
 )
 
 type dsHeadBook struct {
@@ -92,8 +97,8 @@ func (hb *dsHeadBook) SetHeads(t thread.ID, p peer.ID, heads []cid.Cid) error {
 		}
 		entry := &pb.HeadBookRecord_HeadEntry{Cid: &pb.ProtoCid{Cid: heads[i]}}
 		hr.Heads = append(hr.Heads, entry)
-
 	}
+
 	data, err := proto.Marshal(&hr)
 	if err != nil {
 		return fmt.Errorf("error when marshaling headbookrecord proto for %v: %w", key, err)
@@ -130,4 +135,106 @@ func (hb *dsHeadBook) ClearHeads(t thread.ID, p peer.ID) error {
 		return fmt.Errorf("error when deleting heads from %s", key)
 	}
 	return nil
+}
+
+// Dump entire headbook encoded into logstore.DumpHeadBook structure.
+// Not a thread-safe, should not be interleaved with other methods!
+func (hb *dsHeadBook) Dump(w io.Writer) error {
+	data, err := hb.traverse(true)
+	if err != nil {
+		return fmt.Errorf("traversing datastore: %w", err)
+	}
+
+	var dump = logstore.DumpHeadBook{Data: data}
+	return gob.NewEncoder(w).Encode(dump)
+}
+
+// Restore headbook from the stream encoded into logstore.DumpHeadBook
+// structure and replace all the local data with it.
+// Not a thread-safe, should not be interleaved with other methods!
+func (hb *dsHeadBook) Restore(r io.Reader) error {
+	var dump logstore.DumpHeadBook
+	if err := gob.NewDecoder(r).Decode(&dump); err != nil {
+		return fmt.Errorf("decoding dump: %w", err)
+	}
+
+	stored, err := hb.traverse(false)
+	if err != nil {
+		return fmt.Errorf("traversing datastore: %w", err)
+	}
+
+	// wipe out existing headbook
+	for tid, logs := range stored {
+		for lid := range logs {
+			if err := hb.ClearHeads(tid, lid); err != nil {
+				return fmt.Errorf("clearing heads for %s/%s: %w", tid, lid, err)
+			}
+		}
+	}
+
+	// ... and replace it with the dump
+	for tid, logs := range dump.Data {
+		for lid, heads := range logs {
+			if err := hb.SetHeads(tid, lid, heads); err != nil {
+				return fmt.Errorf("setting heads for %s/%s: %w", tid, lid, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (hb *dsHeadBook) traverse(withHeads bool) (map[thread.ID]map[peer.ID][]cid.Cid, error) {
+	var data = make(map[thread.ID]map[peer.ID][]cid.Cid)
+	result, err := hb.ds.Query(query.Query{Prefix: hbBase.String(), KeysOnly: !withHeads})
+	if err != nil {
+		return nil, err
+	}
+
+	for entry := range result.Next() {
+		kns := ds.RawKey(entry.Key).Namespaces()
+		if len(kns) < 3 {
+			return nil, fmt.Errorf("bad headbook key detected: %s", entry.Key)
+		}
+
+		// get thread and log IDs from the key components
+		ts, ls := kns[len(kns)-2], kns[len(kns)-1]
+
+		// parse thread ID
+		pid, _ := base32.RawStdEncoding.DecodeString(ts)
+		tid, err := thread.Cast(pid)
+		if err != nil {
+			return nil, fmt.Errorf("cannot restore thread ID %s: %w", ts, err)
+		}
+
+		// parse log ID
+		pid, _ = base32.RawStdEncoding.DecodeString(ls)
+		lid, err := peer.IDFromBytes(pid)
+		if err != nil {
+			return nil, fmt.Errorf("cannot restore log ID %s: %w", ls, err)
+		}
+
+		var heads []cid.Cid
+		if withHeads {
+			var hr pb.HeadBookRecord
+			if err := proto.Unmarshal(entry.Value, &hr); err != nil {
+				return nil, fmt.Errorf("cannot decode headbook record: %w", err)
+			}
+
+			heads = make([]cid.Cid, len(hr.Heads))
+			for i := range hr.Heads {
+				heads[i] = hr.Heads[i].Cid.Cid
+			}
+		}
+
+		lh, exist := data[tid]
+		if !exist {
+			lh = make(map[peer.ID][]cid.Cid)
+			data[tid] = lh
+		}
+
+		lh[lid] = heads
+	}
+
+	return data, nil
 }

--- a/logstore/lstoreds/headbook.go
+++ b/logstore/lstoreds/headbook.go
@@ -12,7 +12,6 @@ import (
 	core "github.com/textileio/go-threads/core/logstore"
 	"github.com/textileio/go-threads/core/thread"
 	pb "github.com/textileio/go-threads/net/pb"
-	"github.com/whyrusleeping/base32"
 )
 
 type dsHeadBook struct {
@@ -192,15 +191,13 @@ func (hb *dsHeadBook) traverse(withHeads bool) (map[thread.ID]map[peer.ID][]cid.
 		ts, ls := kns[len(kns)-2], kns[len(kns)-1]
 
 		// parse thread ID
-		pid, _ := base32.RawStdEncoding.DecodeString(ts)
-		tid, err := thread.Cast(pid)
+		tid, err := parseThreadID(ts)
 		if err != nil {
 			return nil, fmt.Errorf("cannot restore thread ID %s: %w", ts, err)
 		}
 
 		// parse log ID
-		pid, _ = base32.RawStdEncoding.DecodeString(ls)
-		lid, err := peer.IDFromBytes(pid)
+		lid, err := parseLogID(ls)
 		if err != nil {
 			return nil, fmt.Errorf("cannot restore log ID %s: %w", ls, err)
 		}

--- a/logstore/lstoreds/keybook.go
+++ b/logstore/lstoreds/keybook.go
@@ -318,7 +318,8 @@ func (kb *dsKeyBook) DumpKeys() (core.DumpKeyBook, error) {
 }
 
 func (kb *dsKeyBook) RestoreKeys(dump core.DumpKeyBook) error {
-	if len(dump.Data.Public) == 0 &&
+	if !AllowEmptyRestore &&
+		len(dump.Data.Public) == 0 &&
 		len(dump.Data.Private) == 0 &&
 		len(dump.Data.Read) == 0 &&
 		len(dump.Data.Service) == 0 {

--- a/logstore/lstoreds/keybook.go
+++ b/logstore/lstoreds/keybook.go
@@ -236,6 +236,7 @@ func (kb *dsKeyBook) DumpKeys() (core.DumpKeyBook, error) {
 	if err != nil {
 		return dump, err
 	}
+	defer result.Close()
 
 	for entry := range result.Next() {
 		kns := ds.RawKey(entry.Key).Namespaces()

--- a/logstore/lstoreds/keybook.go
+++ b/logstore/lstoreds/keybook.go
@@ -244,16 +244,16 @@ func (kb *dsKeyBook) DumpKeys() (core.DumpKeyBook, error) {
 		}
 
 		// discriminate by key suffix
-		switch kns[len(kns)-1] {
+		switch suffix := "/" + kns[len(kns)-1]; suffix {
 		case pubSuffix.String():
 			ts, ls := kns[2], kns[3]
 			tid, err := parseThreadID(ts)
 			if err != nil {
-				return dump, fmt.Errorf("cannot restore thread ID %s: %w", ts, err)
+				return dump, fmt.Errorf("cannot parse thread ID %s: %w", ts, err)
 			}
 			lid, err := parseLogID(ls)
 			if err != nil {
-				return dump, fmt.Errorf("cannot restore log ID %s: %w", ls, err)
+				return dump, fmt.Errorf("cannot parse log ID %s: %w", ls, err)
 			}
 			pk, err := crypto.UnmarshalPublicKey(entry.Value)
 			if err != nil {
@@ -270,11 +270,11 @@ func (kb *dsKeyBook) DumpKeys() (core.DumpKeyBook, error) {
 			ts, ls := kns[2], kns[3]
 			tid, err := parseThreadID(ts)
 			if err != nil {
-				return dump, fmt.Errorf("cannot restore thread ID %s: %w", ts, err)
+				return dump, fmt.Errorf("cannot parse thread ID %s: %w", ts, err)
 			}
 			lid, err := parseLogID(ls)
 			if err != nil {
-				return dump, fmt.Errorf("cannot restore log ID %s: %w", ls, err)
+				return dump, fmt.Errorf("cannot parse log ID %s: %w", ls, err)
 			}
 			pk, err := crypto.UnmarshalPrivateKey(entry.Value)
 			if err != nil {
@@ -304,7 +304,7 @@ func (kb *dsKeyBook) DumpKeys() (core.DumpKeyBook, error) {
 			sks[tid] = entry.Value
 
 		default:
-			return dump, fmt.Errorf("bad suffix in a key: %s", entry.Key)
+			return dump, fmt.Errorf("bad suffix %s in a key: %s", suffix, entry.Key)
 		}
 	}
 

--- a/logstore/lstoreds/keybook.go
+++ b/logstore/lstoreds/keybook.go
@@ -222,3 +222,148 @@ func (kb *dsKeyBook) ThreadsFromKeys() (thread.IDSlice, error) {
 	}
 	return ids, nil
 }
+
+func (kb *dsKeyBook) DumpKeys() (core.DumpKeyBook, error) {
+	var (
+		dump core.DumpKeyBook
+		pub  = make(map[thread.ID]map[peer.ID]crypto.PubKey)
+		priv = make(map[thread.ID]map[peer.ID]crypto.PrivKey)
+		rks  = make(map[thread.ID][]byte)
+		sks  = make(map[thread.ID][]byte)
+	)
+
+	result, err := kb.ds.Query(query.Query{Prefix: kbBase.String(), KeysOnly: false})
+	if err != nil {
+		return dump, err
+	}
+
+	for entry := range result.Next() {
+		kns := ds.RawKey(entry.Key).Namespaces()
+		if len(kns) < 4 {
+			return dump, fmt.Errorf("bad keybook key detected: %s", entry.Key)
+		}
+
+		// discriminate by key suffix
+		switch kns[len(kns)-1] {
+		case pubSuffix.String():
+			ts, ls := kns[2], kns[3]
+			tid, err := parseThreadID(ts)
+			if err != nil {
+				return dump, fmt.Errorf("cannot restore thread ID %s: %w", ts, err)
+			}
+			lid, err := parseLogID(ls)
+			if err != nil {
+				return dump, fmt.Errorf("cannot restore log ID %s: %w", ls, err)
+			}
+			pk, err := crypto.UnmarshalPublicKey(entry.Value)
+			if err != nil {
+				return dump, fmt.Errorf("cannot unmarshal public key: %w", err)
+			}
+			pkm, ok := pub[tid]
+			if !ok {
+				pkm = make(map[peer.ID]crypto.PubKey, 1)
+				pub[tid] = pkm
+			}
+			pkm[lid] = pk
+
+		case privSuffix.String():
+			ts, ls := kns[2], kns[3]
+			tid, err := parseThreadID(ts)
+			if err != nil {
+				return dump, fmt.Errorf("cannot restore thread ID %s: %w", ts, err)
+			}
+			lid, err := parseLogID(ls)
+			if err != nil {
+				return dump, fmt.Errorf("cannot restore log ID %s: %w", ls, err)
+			}
+			pk, err := crypto.UnmarshalPrivateKey(entry.Value)
+			if err != nil {
+				return dump, fmt.Errorf("cannot unmarshal private key: %w", err)
+			}
+			pkm, ok := priv[tid]
+			if !ok {
+				pkm = make(map[peer.ID]crypto.PrivKey, 1)
+				priv[tid] = pkm
+			}
+			pkm[lid] = pk
+
+		case readSuffix.String():
+			ts := kns[2]
+			tid, err := parseThreadID(ts)
+			if err != nil {
+				return dump, fmt.Errorf("cannot restore thread ID %s: %w", ts, err)
+			}
+			rks[tid] = entry.Value
+
+		case serviceSuffix.String():
+			ts := kns[2]
+			tid, err := parseThreadID(ts)
+			if err != nil {
+				return dump, fmt.Errorf("cannot restore thread ID %s: %w", ts, err)
+			}
+			sks[tid] = entry.Value
+
+		default:
+			return dump, fmt.Errorf("bad suffix in a key: %s", entry.Key)
+		}
+	}
+
+	dump.Data.Public = pub
+	dump.Data.Private = priv
+	dump.Data.Read = rks
+	dump.Data.Service = sks
+
+	return dump, nil
+}
+
+func (kb *dsKeyBook) RestoreKeys(dump core.DumpKeyBook) error {
+	if len(dump.Data.Public) == 0 &&
+		len(dump.Data.Private) == 0 &&
+		len(dump.Data.Read) == 0 &&
+		len(dump.Data.Service) == 0 {
+		return core.ErrEmptyDump
+	}
+
+	// clear all local keys
+	if err := kb.clearKeys(kbBase); err != nil {
+		return err
+	}
+
+	for tid, logs := range dump.Data.Public {
+		for lid, pubKey := range logs {
+			if err := kb.AddPubKey(tid, lid, pubKey); err != nil {
+				return err
+			}
+		}
+	}
+
+	for tid, logs := range dump.Data.Private {
+		for lid, privKey := range logs {
+			if err := kb.AddPrivKey(tid, lid, privKey); err != nil {
+				return err
+			}
+		}
+	}
+
+	for tid, rk := range dump.Data.Read {
+		key, err := sym.FromBytes(rk)
+		if err != nil {
+			return fmt.Errorf("decoding read key for thread %s: %w", tid, err)
+		}
+		if err := kb.AddReadKey(tid, key); err != nil {
+			return err
+		}
+	}
+
+	for tid, sk := range dump.Data.Service {
+		key, err := sym.FromBytes(sk)
+		if err != nil {
+			return fmt.Errorf("decoding service key for thread %s: %w", tid, err)
+		}
+		if err := kb.AddServiceKey(tid, key); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/logstore/lstoreds/logstore.go
+++ b/logstore/lstoreds/logstore.go
@@ -87,8 +87,7 @@ func uniqueThreadIds(ds ds.Datastore, prefix ds.Key, extractor func(result query
 
 	ids := make(thread.IDSlice, 0, len(idset))
 	for id := range idset {
-		pid, _ := base32.RawStdEncoding.DecodeString(id)
-		id, err := thread.Cast(pid)
+		id, err := parseThreadID(id)
 		if err == nil {
 			ids = append(ids, id)
 		}
@@ -123,8 +122,7 @@ func uniqueLogIds(ds ds.Datastore, prefix ds.Key, extractor func(result query.Re
 
 	ids := make(peer.IDSlice, 0, len(idset))
 	for id := range idset {
-		pid, _ := base32.RawStdEncoding.DecodeString(id)
-		id, err := peer.IDFromBytes(pid)
+		id, err := parseLogID(id)
 		if err == nil {
 			ids = append(ids, id)
 		}
@@ -141,4 +139,22 @@ func dsLogKey(t thread.ID, p peer.ID, baseKey ds.Key) ds.Key {
 	key := baseKey.ChildString(base32.RawStdEncoding.EncodeToString(t.Bytes()))
 	key = key.ChildString(base32.RawStdEncoding.EncodeToString([]byte(p)))
 	return key
+}
+
+func parseThreadID(id string) (thread.ID, error) {
+	pid, err := base32.RawStdEncoding.DecodeString(id)
+	if err != nil {
+		return thread.Undef, err
+	}
+
+	return thread.Cast(pid)
+}
+
+func parseLogID(id string) (peer.ID, error) {
+	pid, err := base32.RawStdEncoding.DecodeString(id)
+	if err != nil {
+		return "", err
+	}
+
+	return peer.IDFromBytes(pid)
 }

--- a/logstore/lstoreds/logstore.go
+++ b/logstore/lstoreds/logstore.go
@@ -13,6 +13,9 @@ import (
 	"github.com/whyrusleeping/base32"
 )
 
+// Define if storage will accept empty dumps.
+var AllowEmptyRestore = false
+
 // Configuration object for datastores
 type Options struct {
 	// The size of the in-memory cache. A value of 0 or lower disables the cache.

--- a/logstore/lstoreds/metadata.go
+++ b/logstore/lstoreds/metadata.go
@@ -217,7 +217,7 @@ func (m *dsThreadMetadata) RestoreMeta(dump core.DumpMetadata) error {
 		len(dump.Data.Int64) +
 		len(dump.Data.String) +
 		len(dump.Data.Bytes)
-	if dataLen == 0 {
+	if !AllowEmptyRestore && dataLen == 0 {
 		return core.ErrEmptyDump
 	}
 

--- a/logstore/lstoreds/metadata.go
+++ b/logstore/lstoreds/metadata.go
@@ -129,11 +129,110 @@ func (m *dsThreadMetadata) setValue(t thread.ID, key string, val interface{}) er
 }
 
 func (m *dsThreadMetadata) ClearMetadata(t thread.ID) error {
-	q := query.Query{
-		Prefix:   tmetaBase.ChildString(base32.RawStdEncoding.EncodeToString(t.Bytes())).String(),
-		KeysOnly: true,
+	return m.clearKeys(tmetaBase.ChildString(base32.RawStdEncoding.EncodeToString(t.Bytes())).String())
+}
+
+func (m *dsThreadMetadata) DumpMeta() (core.DumpMetadata, error) {
+	var (
+		vInt64  = make(map[core.MetadataKey]int64)
+		vBool   = make(map[core.MetadataKey]bool)
+		vString = make(map[core.MetadataKey]string)
+		vBytes  = make(map[core.MetadataKey][]byte)
+
+		buff bytes.Buffer
+		dump core.DumpMetadata
+		dec  = gob.NewDecoder(&buff)
+	)
+
+	results, err := m.ds.Query(query.Query{Prefix: tmetaBase.String()})
+	if err != nil {
+		return dump, err
 	}
-	results, err := m.ds.Query(q)
+	defer results.Close()
+
+	for entry := range results.Next() {
+		kns := ds.RawKey(entry.Key).Namespaces()
+		if len(kns) < 4 {
+			return dump, fmt.Errorf("bad metabook key detected: %s", entry.Key)
+		}
+
+		ts, key := kns[2], kns[3]
+		tid, err := parseThreadID(ts)
+		if err != nil {
+			return dump, fmt.Errorf("cannot parse thread ID %s: %w", ts, err)
+		}
+
+		var (
+			mk    = core.MetadataKey{T: tid, K: key}
+			value interface{}
+		)
+
+		buff.Write(entry.Value)
+		if err := dec.Decode(&value); err != nil {
+			return dump, fmt.Errorf("decoding value: %w", err)
+		}
+
+		switch v := value.(type) {
+		case bool:
+			vBool[mk] = v
+		case int64:
+			vInt64[mk] = v
+		case string:
+			vString[mk] = v
+		case []byte:
+			vBytes[mk] = v
+		default:
+			return dump, fmt.Errorf("unsupported value type %T, key: %v, value: %v", value, mk, value)
+		}
+		buff.Reset()
+	}
+
+	dump.Data.Bool = vBool
+	dump.Data.Int64 = vInt64
+	dump.Data.String = vString
+	dump.Data.Bytes = vBytes
+	return dump, nil
+}
+
+func (m *dsThreadMetadata) RestoreMeta(dump core.DumpMetadata) error {
+	var dataLen = len(dump.Data.Bool) +
+		len(dump.Data.Int64) +
+		len(dump.Data.String) +
+		len(dump.Data.Bytes)
+	if dataLen == 0 {
+		return core.ErrEmptyDump
+	}
+
+	if err := m.clearKeys(tmetaBase.String()); err != nil {
+		return err
+	}
+
+	for mk, val := range dump.Data.Bool {
+		if err := m.setValue(mk.T, mk.K, val); err != nil {
+			return err
+		}
+	}
+	for mk, val := range dump.Data.Int64 {
+		if err := m.setValue(mk.T, mk.K, val); err != nil {
+			return err
+		}
+	}
+	for mk, val := range dump.Data.String {
+		if err := m.setValue(mk.T, mk.K, val); err != nil {
+			return err
+		}
+	}
+	for mk, val := range dump.Data.Bytes {
+		if err := m.setValue(mk.T, mk.K, val); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *dsThreadMetadata) clearKeys(prefix string) error {
+	results, err := m.ds.Query(query.Query{Prefix: prefix, KeysOnly: true})
 	if err != nil {
 		return err
 	}

--- a/logstore/lstorehybrid/hybrid_test.go
+++ b/logstore/lstorehybrid/hybrid_test.go
@@ -1,0 +1,152 @@
+package lstorehybrid
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	badger "github.com/ipfs/go-ds-badger"
+	core "github.com/textileio/go-threads/core/logstore"
+	"github.com/textileio/go-threads/logstore/lstoreds"
+	m "github.com/textileio/go-threads/logstore/lstoremem"
+	pt "github.com/textileio/go-threads/test"
+)
+
+type storeFactory func(tb testing.TB) (core.Logstore, func())
+
+var (
+	persist = map[string]storeFactory{
+		"lstoreds:Badger": lstoredsBadgerF,
+	}
+
+	inMem = map[string]storeFactory{
+		"lstoremem": lstorememF,
+	}
+)
+
+func TestHybridLogstore(t *testing.T) {
+	for psName, psF := range persist {
+		for msName, msF := range inMem {
+			t.Run(psName+"+"+msName, func(t *testing.T) {
+				t.Parallel()
+				pt.LogstoreTest(t, logstoreFactory(t, psF, msF))
+			})
+		}
+	}
+}
+
+func TestHybridAddrBook(t *testing.T) {
+	for psName, psF := range persist {
+		for msName, msF := range inMem {
+			t.Run(psName+"+"+msName, func(t *testing.T) {
+				t.Parallel()
+				pt.AddrBookTest(t, adapterAddrBook(logstoreFactory(t, psF, msF)))
+			})
+		}
+	}
+}
+
+func TestHybridKeyBook(t *testing.T) {
+	for psName, psF := range persist {
+		for msName, msF := range inMem {
+			t.Run(psName+"+"+msName, func(t *testing.T) {
+				t.Parallel()
+				pt.KeyBookTest(t, adapterKeyBook(logstoreFactory(t, psF, msF)))
+			})
+		}
+	}
+}
+
+func TestHybridHeadBook(t *testing.T) {
+	for psName, psF := range persist {
+		for msName, msF := range inMem {
+			t.Run(psName+"+"+msName, func(t *testing.T) {
+				t.Parallel()
+				pt.HeadBookTest(t, adapterHeadBook(logstoreFactory(t, psF, msF)))
+			})
+		}
+	}
+}
+
+func TestHybridMetadataBook(t *testing.T) {
+	for psName, psF := range persist {
+		for msName, msF := range inMem {
+			t.Run(psName+"+"+msName, func(t *testing.T) {
+				t.Parallel()
+				pt.MetadataBookTest(t, adapterMetaBook(logstoreFactory(t, psF, msF)))
+			})
+		}
+	}
+}
+
+/* store factories */
+
+func logstoreFactory(tb testing.TB, persistF, memF storeFactory) pt.LogstoreFactory {
+	return func() (core.Logstore, func()) {
+		ps, psClose := persistF(tb)
+		ms, msClose := memF(tb)
+
+		ls, err := NewLogstore(ps, ms)
+		if err != nil {
+			tb.Fatal(err)
+		}
+
+		closer := func() {
+			_ = ls.Close()
+			psClose()
+			msClose()
+		}
+
+		return ls, closer
+	}
+}
+
+func lstoredsBadgerF(tb testing.TB) (core.Logstore, func()) {
+	dataPath, err := ioutil.TempDir(os.TempDir(), "badger")
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	backend, err := badger.NewDatastore(dataPath, nil)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	lstore, err := lstoreds.NewLogstore(
+		context.Background(),
+		backend,
+		lstoreds.DefaultOpts(),
+	)
+
+	closer := func() {
+		_ = lstore.Close()
+		_ = backend.Close()
+		_ = os.RemoveAll(dataPath)
+	}
+
+	return lstore, closer
+}
+
+func lstorememF(_ testing.TB) (core.Logstore, func()) {
+	store := m.NewLogstore()
+	return store, func() { _ = store.Close() }
+}
+
+/* component adapters */
+
+func adapterAddrBook(f pt.LogstoreFactory) pt.AddrBookFactory {
+	return func() (core.AddrBook, func()) { return f() }
+}
+
+func adapterKeyBook(f pt.LogstoreFactory) pt.KeyBookFactory {
+	return func() (core.KeyBook, func()) { return f() }
+}
+
+func adapterHeadBook(f pt.LogstoreFactory) pt.HeadBookFactory {
+	return func() (core.HeadBook, func()) { return f() }
+}
+
+func adapterMetaBook(f pt.LogstoreFactory) pt.MetadataBookFactory {
+	return func() (core.ThreadMetadata, func()) { return f() }
+}

--- a/logstore/lstorehybrid/logstore.go
+++ b/logstore/lstorehybrid/logstore.go
@@ -1,0 +1,367 @@
+package lstorehybrid
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/peer"
+	ma "github.com/multiformats/go-multiaddr"
+	core "github.com/textileio/go-threads/core/logstore"
+	"github.com/textileio/go-threads/core/thread"
+	sym "github.com/textileio/go-threads/crypto/symmetric"
+)
+
+var _ core.Logstore = (*lstore)(nil)
+
+type lstore struct {
+	inMem, persist core.Logstore
+}
+
+func NewLogstore(persist, inMem core.Logstore) (*lstore, error) {
+	// on a start it's required to synchronize both storages, so we
+	// initialize in-memory storage with data from the persistent one
+	dKeys, err := persist.DumpKeys()
+	if err != nil {
+		return nil, fmt.Errorf("dumping keys from persistent storage: %w", err)
+	}
+	dAddrs, err := persist.DumpAddrs()
+	if err != nil {
+		return nil, fmt.Errorf("dumping addresses from persistent storage: %w", err)
+	}
+	dHeads, err := persist.DumpHeads()
+	if err != nil {
+		return nil, fmt.Errorf("dumping heads from persistent storage: %w", err)
+	}
+	dMeta, err := persist.DumpMeta()
+	if err != nil {
+		return nil, fmt.Errorf("dumping metadata from persistent storage: %w", err)
+	}
+
+	// initialize in-memory storage
+	if err := inMem.RestoreKeys(dKeys); err != nil {
+		return nil, fmt.Errorf("initializing in-memory storage with keys: %w", err)
+	}
+	if err := inMem.RestoreAddrs(dAddrs); err != nil {
+		return nil, fmt.Errorf("initializing in-memory storage with addresses: %w", err)
+	}
+	if err := inMem.RestoreHeads(dHeads); err != nil {
+		return nil, fmt.Errorf("initializing in-memory storage with heads: %w", err)
+	}
+	if err := inMem.RestoreMeta(dMeta); err != nil {
+		return nil, fmt.Errorf("initializing in-memory storage with metadata: %w", err)
+	}
+
+	return &lstore{inMem: inMem, persist: persist}, nil
+}
+
+func (l *lstore) Close() error {
+	if err := l.persist.Close(); err != nil {
+		return err
+	}
+	return l.inMem.Close()
+}
+
+func (l *lstore) GetInt64(tid thread.ID, key string) (*int64, error) {
+	return l.inMem.GetInt64(tid, key)
+}
+
+func (l *lstore) PutInt64(tid thread.ID, key string, val int64) error {
+	if err := l.persist.PutInt64(tid, key, val); err != nil {
+		return err
+	}
+	return l.inMem.PutInt64(tid, key, val)
+}
+
+func (l *lstore) GetString(tid thread.ID, key string) (*string, error) {
+	return l.inMem.GetString(tid, key)
+}
+
+func (l *lstore) PutString(tid thread.ID, key string, val string) error {
+	if err := l.persist.PutString(tid, key, val); err != nil {
+		return err
+	}
+	return l.inMem.PutString(tid, key, val)
+}
+
+func (l *lstore) GetBool(tid thread.ID, key string) (*bool, error) {
+	return l.inMem.GetBool(tid, key)
+}
+
+func (l *lstore) PutBool(tid thread.ID, key string, val bool) error {
+	if err := l.persist.PutBool(tid, key, val); err != nil {
+		return err
+	}
+	return l.inMem.PutBool(tid, key, val)
+}
+
+func (l *lstore) GetBytes(tid thread.ID, key string) (*[]byte, error) {
+	return l.inMem.GetBytes(tid, key)
+}
+
+func (l *lstore) PutBytes(tid thread.ID, key string, val []byte) error {
+	if err := l.persist.PutBytes(tid, key, val); err != nil {
+		return err
+	}
+	return l.inMem.PutBytes(tid, key, val)
+}
+
+func (l *lstore) ClearMetadata(tid thread.ID) error {
+	if err := l.persist.ClearMetadata(tid); err != nil {
+		return err
+	}
+	return l.inMem.ClearMetadata(tid)
+}
+
+func (l *lstore) PubKey(tid thread.ID, lid peer.ID) (crypto.PubKey, error) {
+	return l.inMem.PubKey(tid, lid)
+}
+
+func (l *lstore) AddPubKey(tid thread.ID, lid peer.ID, key crypto.PubKey) error {
+	if err := l.persist.AddPubKey(tid, lid, key); err != nil {
+		return err
+	}
+	return l.inMem.AddPubKey(tid, lid, key)
+}
+
+func (l *lstore) PrivKey(tid thread.ID, lid peer.ID) (crypto.PrivKey, error) {
+	return l.inMem.PrivKey(tid, lid)
+}
+
+func (l *lstore) AddPrivKey(tid thread.ID, lid peer.ID, key crypto.PrivKey) error {
+	if err := l.persist.AddPrivKey(tid, lid, key); err != nil {
+		return err
+	}
+	return l.inMem.AddPrivKey(tid, lid, key)
+}
+
+func (l *lstore) ReadKey(tid thread.ID) (*sym.Key, error) {
+	return l.inMem.ReadKey(tid)
+}
+
+func (l *lstore) AddReadKey(tid thread.ID, key *sym.Key) error {
+	if err := l.persist.AddReadKey(tid, key); err != nil {
+		return err
+	}
+	return l.inMem.AddReadKey(tid, key)
+}
+
+func (l *lstore) ServiceKey(tid thread.ID) (*sym.Key, error) {
+	return l.inMem.ServiceKey(tid)
+}
+
+func (l *lstore) AddServiceKey(tid thread.ID, key *sym.Key) error {
+	if err := l.persist.AddServiceKey(tid, key); err != nil {
+		return err
+	}
+	return l.inMem.AddServiceKey(tid, key)
+}
+
+func (l *lstore) ClearKeys(tid thread.ID) error {
+	if err := l.persist.ClearKeys(tid); err != nil {
+		return err
+	}
+	return l.inMem.ClearKeys(tid)
+}
+
+func (l *lstore) ClearLogKeys(tid thread.ID, lid peer.ID) error {
+	if err := l.persist.ClearLogKeys(tid, lid); err != nil {
+		return err
+	}
+	return l.inMem.ClearLogKeys(tid, lid)
+}
+
+func (l *lstore) LogsWithKeys(tid thread.ID) (peer.IDSlice, error) {
+	return l.inMem.LogsWithKeys(tid)
+}
+
+func (l *lstore) ThreadsFromKeys() (thread.IDSlice, error) {
+	return l.inMem.ThreadsFromKeys()
+}
+
+func (l *lstore) AddAddr(tid thread.ID, lid peer.ID, addr ma.Multiaddr, dur time.Duration) error {
+	if err := l.persist.AddAddr(tid, lid, addr, dur); err != nil {
+		return err
+	}
+	return l.inMem.AddAddr(tid, lid, addr, dur)
+}
+
+func (l *lstore) AddAddrs(tid thread.ID, lid peer.ID, addrs []ma.Multiaddr, dur time.Duration) error {
+	if err := l.persist.AddAddrs(tid, lid, addrs, dur); err != nil {
+		return err
+	}
+	return l.inMem.AddAddrs(tid, lid, addrs, dur)
+}
+
+func (l *lstore) SetAddr(tid thread.ID, lid peer.ID, addr ma.Multiaddr, dur time.Duration) error {
+	if err := l.persist.SetAddr(tid, lid, addr, dur); err != nil {
+		return err
+	}
+	return l.inMem.SetAddr(tid, lid, addr, dur)
+}
+
+func (l *lstore) SetAddrs(tid thread.ID, lid peer.ID, addrs []ma.Multiaddr, dur time.Duration) error {
+	if err := l.persist.SetAddrs(tid, lid, addrs, dur); err != nil {
+		return err
+	}
+	return l.inMem.SetAddrs(tid, lid, addrs, dur)
+}
+
+func (l *lstore) UpdateAddrs(tid thread.ID, lid peer.ID, oldTTL time.Duration, newTTL time.Duration) error {
+	if err := l.persist.UpdateAddrs(tid, lid, oldTTL, newTTL); err != nil {
+		return err
+	}
+	return l.inMem.UpdateAddrs(tid, lid, oldTTL, newTTL)
+}
+
+func (l *lstore) Addrs(tid thread.ID, lid peer.ID) ([]ma.Multiaddr, error) {
+	return l.inMem.Addrs(tid, lid)
+}
+
+func (l *lstore) AddrStream(ctx context.Context, tid thread.ID, lid peer.ID) (<-chan ma.Multiaddr, error) {
+	return l.inMem.AddrStream(ctx, tid, lid)
+}
+
+func (l *lstore) ClearAddrs(tid thread.ID, lid peer.ID) error {
+	if err := l.persist.ClearAddrs(tid, lid); err != nil {
+		return err
+	}
+	return l.inMem.ClearAddrs(tid, lid)
+}
+
+func (l *lstore) LogsWithAddrs(tid thread.ID) (peer.IDSlice, error) {
+	return l.inMem.LogsWithAddrs(tid)
+}
+
+func (l *lstore) ThreadsFromAddrs() (thread.IDSlice, error) {
+	return l.inMem.ThreadsFromAddrs()
+}
+
+func (l *lstore) AddHead(tid thread.ID, lid peer.ID, cid cid.Cid) error {
+	if err := l.persist.AddHead(tid, lid, cid); err != nil {
+		return err
+	}
+	return l.inMem.AddHead(tid, lid, cid)
+}
+
+func (l *lstore) AddHeads(tid thread.ID, lid peer.ID, cids []cid.Cid) error {
+	if err := l.persist.AddHeads(tid, lid, cids); err != nil {
+		return err
+	}
+	return l.inMem.AddHeads(tid, lid, cids)
+}
+
+func (l *lstore) SetHead(tid thread.ID, lid peer.ID, cid cid.Cid) error {
+	if err := l.persist.SetHead(tid, lid, cid); err != nil {
+		return err
+	}
+	return l.inMem.SetHead(tid, lid, cid)
+}
+
+func (l *lstore) SetHeads(tid thread.ID, lid peer.ID, cids []cid.Cid) error {
+	if err := l.persist.SetHeads(tid, lid, cids); err != nil {
+		return err
+	}
+	return l.inMem.SetHeads(tid, lid, cids)
+}
+
+func (l *lstore) Heads(tid thread.ID, lid peer.ID) ([]cid.Cid, error) {
+	return l.inMem.Heads(tid, lid)
+}
+
+func (l *lstore) ClearHeads(tid thread.ID, lid peer.ID) error {
+	if err := l.persist.ClearHeads(tid, lid); err != nil {
+		return err
+	}
+	return l.inMem.ClearHeads(tid, lid)
+}
+
+func (l *lstore) Threads() (thread.IDSlice, error) {
+	return l.inMem.Threads()
+}
+
+func (l *lstore) AddThread(info thread.Info) error {
+	if err := l.persist.AddThread(info); err != nil {
+		return err
+	}
+	return l.inMem.AddThread(info)
+}
+
+func (l *lstore) GetThread(tid thread.ID) (thread.Info, error) {
+	return l.inMem.GetThread(tid)
+}
+
+func (l *lstore) DeleteThread(tid thread.ID) error {
+	if err := l.persist.DeleteThread(tid); err != nil {
+		return err
+	}
+	return l.inMem.DeleteThread(tid)
+}
+
+func (l *lstore) AddLog(tid thread.ID, info thread.LogInfo) error {
+	if err := l.persist.AddLog(tid, info); err != nil {
+		return err
+	}
+	return l.inMem.AddLog(tid, info)
+}
+
+func (l *lstore) GetLog(tid thread.ID, lid peer.ID) (thread.LogInfo, error) {
+	return l.inMem.GetLog(tid, lid)
+}
+
+func (l *lstore) GetManagedLogs(tid thread.ID) ([]thread.LogInfo, error) {
+	return l.inMem.GetManagedLogs(tid)
+}
+
+func (l *lstore) DeleteLog(tid thread.ID, lid peer.ID) error {
+	if err := l.persist.DeleteLog(tid, lid); err != nil {
+		return err
+	}
+	return l.inMem.DeleteLog(tid, lid)
+}
+
+func (l *lstore) DumpMeta() (core.DumpMetadata, error) {
+	return l.inMem.DumpMeta()
+}
+
+func (l *lstore) RestoreMeta(dump core.DumpMetadata) error {
+	if err := l.persist.RestoreMeta(dump); err != nil {
+		return err
+	}
+	return l.inMem.RestoreMeta(dump)
+}
+
+func (l *lstore) DumpKeys() (core.DumpKeyBook, error) {
+	return l.inMem.DumpKeys()
+}
+
+func (l *lstore) RestoreKeys(dump core.DumpKeyBook) error {
+	if err := l.persist.RestoreKeys(dump); err != nil {
+		return err
+	}
+	return l.inMem.RestoreKeys(dump)
+}
+
+func (l *lstore) DumpAddrs() (core.DumpAddrBook, error) {
+	return l.inMem.DumpAddrs()
+}
+
+func (l *lstore) RestoreAddrs(dump core.DumpAddrBook) error {
+	if err := l.persist.RestoreAddrs(dump); err != nil {
+		return err
+	}
+	return l.inMem.RestoreAddrs(dump)
+}
+
+func (l *lstore) DumpHeads() (core.DumpHeadBook, error) {
+	return l.inMem.DumpHeads()
+}
+
+func (l *lstore) RestoreHeads(dump core.DumpHeadBook) error {
+	if err := l.persist.RestoreHeads(dump); err != nil {
+		return err
+	}
+	return l.inMem.RestoreHeads(dump)
+}

--- a/logstore/lstoremem/addr_book.go
+++ b/logstore/lstoremem/addr_book.go
@@ -56,6 +56,7 @@ type memoryAddrBook struct {
 
 	ctx    context.Context
 	cancel func()
+	gcLock sync.Mutex
 
 	subManager *AddrSubManager
 }
@@ -104,7 +105,10 @@ func (mab *memoryAddrBook) Close() error {
 
 // gc garbage collects the in-memory address book.
 func (mab *memoryAddrBook) gc() {
-	now := time.Now()
+	mab.gcLock.Lock()
+	defer mab.gcLock.Unlock()
+
+	var now = time.Now()
 	for _, s := range mab.segments {
 		s.Lock()
 		for t, pmap := range s.addrs {
@@ -187,11 +191,16 @@ func (mab *memoryAddrBook) AddAddrs(t thread.ID, p peer.ID, addrs []ma.Multiaddr
 			log.Warnf("was passed nil multiaddr for %s", p)
 			continue
 		}
-		asBytes := a.Bytes()
-		x, found := amap[string(asBytes)] // won't allocate.
+		// It's cheaper than using String(), but unfortunately it will
+		// copy bytes on conversion anyway just to ensure that string
+		// contents are immutable and independent from the original
+		// buffer. Zero-copy conversion could be done with unsafe but
+		// in this case it's not worth bothering with.
+		asStr := string(a.Bytes())
+		x, found := amap[asStr]
 		if !found {
 			// not found, save and announce it.
-			amap[string(asBytes)] = &expiringAddr{Addr: a, Expires: exp, TTL: ttl}
+			amap[asStr] = &expiringAddr{Addr: a, Expires: exp, TTL: ttl}
 			mab.subManager.BroadcastAddr(p, a)
 		} else {
 			// Update expiration/TTL independently.
@@ -322,6 +331,76 @@ func (mab *memoryAddrBook) AddrStream(ctx context.Context, t thread.ID, p peer.I
 	}
 
 	return mab.subManager.AddrStream(ctx, p, initial)
+}
+
+func (mab *memoryAddrBook) DumpAddrs() (core.DumpAddrBook, error) {
+	var dump = core.DumpAddrBook{
+		Data: make(map[thread.ID]map[peer.ID][]core.ExpiredAddress, 256),
+	}
+
+	mab.gcLock.Lock()
+	var now = time.Now()
+
+	for _, segment := range mab.segments {
+		for tid, logs := range segment.addrs {
+			lm, exist := dump.Data[tid]
+			if !exist {
+				lm = make(map[peer.ID][]core.ExpiredAddress, len(logs))
+				dump.Data[tid] = lm
+			}
+
+			for lid, addrMap := range logs {
+				for _, ap := range addrMap {
+					if ap != nil && !ap.ExpiredBy(now) {
+						lm[lid] = append(lm[lid], core.ExpiredAddress{
+							Addr:    ap.Addr,
+							Expires: ap.Expires,
+						})
+					}
+				}
+			}
+		}
+	}
+	mab.gcLock.Unlock()
+	return dump, nil
+}
+
+func (mab *memoryAddrBook) RestoreAddrs(dump core.DumpAddrBook) error {
+	mab.gcLock.Lock()
+	defer mab.gcLock.Unlock()
+
+	// reset segments
+	for i := range mab.segments {
+		mab.segments[i] = &addrSegment{
+			addrs: make(map[thread.ID]map[peer.ID]map[string]*expiringAddr, len(mab.segments[i].addrs)),
+		}
+	}
+
+	var now = time.Now()
+	for tid, logs := range dump.Data {
+		for lid, addrs := range logs {
+			s := mab.segments.get(lid)
+			am, _ := s.getAddrs(tid, lid)
+			if am == nil {
+				if s.addrs[tid] == nil {
+					s.addrs[tid] = make(map[peer.ID]map[string]*expiringAddr, 1)
+				}
+				am = make(map[string]*expiringAddr, len(addrs))
+				s.addrs[tid][lid] = am
+			}
+
+			for _, rec := range addrs {
+				if rec.Expires.After(now) {
+					am[string(rec.Addr.Bytes())] = &expiringAddr{
+						Addr:    rec.Addr,
+						TTL:     rec.Expires.Sub(now),
+						Expires: rec.Expires,
+					}
+				}
+			}
+		}
+	}
+	return nil
 }
 
 type addrSub struct {

--- a/logstore/lstoremem/addr_book.go
+++ b/logstore/lstoremem/addr_book.go
@@ -2,7 +2,6 @@ package lstoremem
 
 import (
 	"context"
-	"errors"
 	"sort"
 	"sync"
 	"time"
@@ -368,7 +367,7 @@ func (mab *memoryAddrBook) DumpAddrs() (core.DumpAddrBook, error) {
 
 func (mab *memoryAddrBook) RestoreAddrs(dump core.DumpAddrBook) error {
 	if len(dump.Data) == 0 {
-		return errors.New("empty dump")
+		return core.ErrEmptyDump
 	}
 
 	mab.gcLock.Lock()

--- a/logstore/lstoremem/addr_book.go
+++ b/logstore/lstoremem/addr_book.go
@@ -361,7 +361,7 @@ func (mab *memoryAddrBook) DumpAddrs() (core.DumpAddrBook, error) {
 }
 
 func (mab *memoryAddrBook) RestoreAddrs(dump core.DumpAddrBook) error {
-	if len(dump.Data) == 0 {
+	if !AllowEmptyRestore && len(dump.Data) == 0 {
 		return core.ErrEmptyDump
 	}
 

--- a/logstore/lstoremem/addr_book.go
+++ b/logstore/lstoremem/addr_book.go
@@ -191,16 +191,11 @@ func (mab *memoryAddrBook) AddAddrs(t thread.ID, p peer.ID, addrs []ma.Multiaddr
 			log.Warnf("was passed nil multiaddr for %s", p)
 			continue
 		}
-		// It's cheaper than using String(), but unfortunately it will
-		// copy bytes on conversion anyway just to ensure that string
-		// contents are immutable and independent from the original
-		// buffer. Zero-copy conversion could be done with unsafe but
-		// in this case it's not worth bothering with.
-		asStr := string(a.Bytes())
-		x, found := amap[asStr]
+		asBytes := a.Bytes()
+		x, found := amap[string(asBytes)] // won't allocate.
 		if !found {
 			// not found, save and announce it.
-			amap[asStr] = &expiringAddr{Addr: a, Expires: exp, TTL: ttl}
+			amap[string(asBytes)] = &expiringAddr{Addr: a, Expires: exp, TTL: ttl}
 			mab.subManager.BroadcastAddr(p, a)
 		} else {
 			// Update expiration/TTL independently.

--- a/logstore/lstoremem/addr_book.go
+++ b/logstore/lstoremem/addr_book.go
@@ -2,6 +2,7 @@ package lstoremem
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"sync"
 	"time"
@@ -366,6 +367,10 @@ func (mab *memoryAddrBook) DumpAddrs() (core.DumpAddrBook, error) {
 }
 
 func (mab *memoryAddrBook) RestoreAddrs(dump core.DumpAddrBook) error {
+	if len(dump.Data) == 0 {
+		return errors.New("empty dump")
+	}
+
 	mab.gcLock.Lock()
 	defer mab.gcLock.Unlock()
 

--- a/logstore/lstoremem/headbook.go
+++ b/logstore/lstoremem/headbook.go
@@ -136,7 +136,7 @@ func (mhb *memoryHeadBook) DumpHeads() (core.DumpHeadBook, error) {
 }
 
 func (mhb *memoryHeadBook) RestoreHeads(dump core.DumpHeadBook) error {
-	if len(dump.Data) == 0 {
+	if !AllowEmptyRestore && len(dump.Data) == 0 {
 		return core.ErrEmptyDump
 	}
 

--- a/logstore/lstoremem/headbook.go
+++ b/logstore/lstoremem/headbook.go
@@ -1,7 +1,6 @@
 package lstoremem
 
 import (
-	"errors"
 	"sync"
 
 	"github.com/ipfs/go-cid"
@@ -138,7 +137,7 @@ func (mhb *memoryHeadBook) DumpHeads() (core.DumpHeadBook, error) {
 
 func (mhb *memoryHeadBook) RestoreHeads(dump core.DumpHeadBook) error {
 	if len(dump.Data) == 0 {
-		return errors.New("empty dump")
+		return core.ErrEmptyDump
 	}
 
 	var restored = make(map[thread.ID]map[peer.ID]map[cid.Cid]struct{}, len(dump.Data))

--- a/logstore/lstoremem/headbook.go
+++ b/logstore/lstoremem/headbook.go
@@ -1,6 +1,7 @@
 package lstoremem
 
 import (
+	"errors"
 	"sync"
 
 	"github.com/ipfs/go-cid"
@@ -136,6 +137,10 @@ func (mhb *memoryHeadBook) DumpHeads() (core.DumpHeadBook, error) {
 }
 
 func (mhb *memoryHeadBook) RestoreHeads(dump core.DumpHeadBook) error {
+	if len(dump.Data) == 0 {
+		return errors.New("empty dump")
+	}
+
 	var restored = make(map[thread.ID]map[peer.ID]map[cid.Cid]struct{}, len(dump.Data))
 	for tid, logs := range dump.Data {
 		lm := make(map[peer.ID]map[cid.Cid]struct{}, len(logs))

--- a/logstore/lstoremem/keybook.go
+++ b/logstore/lstoremem/keybook.go
@@ -240,7 +240,8 @@ func (mkb *memoryKeyBook) DumpKeys() (core.DumpKeyBook, error) {
 }
 
 func (mkb *memoryKeyBook) RestoreKeys(dump core.DumpKeyBook) error {
-	if len(dump.Data.Public) == 0 &&
+	if !AllowEmptyRestore &&
+		len(dump.Data.Public) == 0 &&
 		len(dump.Data.Private) == 0 &&
 		len(dump.Data.Read) == 0 &&
 		len(dump.Data.Service) == 0 {

--- a/logstore/lstoremem/logstore.go
+++ b/logstore/lstoremem/logstore.go
@@ -5,6 +5,9 @@ import (
 	lstore "github.com/textileio/go-threads/logstore"
 )
 
+// Define if storage will accept empty dumps.
+var AllowEmptyRestore = true
+
 // NewLogstore creates an in-memory threadsafe collection of thread logs.
 func NewLogstore() core.Logstore {
 	return lstore.NewLogstore(

--- a/logstore/lstoremem/metadata.go
+++ b/logstore/lstoremem/metadata.go
@@ -145,7 +145,7 @@ func (m *memoryThreadMetadata) RestoreMeta(dump core.DumpMetadata) error {
 	}
 
 	m.dslock.Lock()
-	defer m.dslock.RUnlock()
+	defer m.dslock.Unlock()
 
 	// clear local data
 	m.ds = make(map[core.MetadataKey]interface{}, dataLen)

--- a/logstore/lstoremem/metadata.go
+++ b/logstore/lstoremem/metadata.go
@@ -1,33 +1,23 @@
 package lstoremem
 
 import (
+	"fmt"
 	"sync"
 
 	core "github.com/textileio/go-threads/core/logstore"
 	"github.com/textileio/go-threads/core/thread"
 )
 
-var internKeys = map[string]bool{
-	"Name": true,
-}
-
-type metakey struct {
-	id  thread.ID
-	key string
-}
-
 type memoryThreadMetadata struct {
-	ds       map[metakey]interface{}
-	dslock   sync.RWMutex
-	interned map[string]interface{}
+	ds     map[core.MetadataKey]interface{}
+	dslock sync.RWMutex
 }
 
 var _ core.ThreadMetadata = (*memoryThreadMetadata)(nil)
 
 func NewThreadMetadata() core.ThreadMetadata {
 	return &memoryThreadMetadata{
-		ds:       make(map[metakey]interface{}),
-		interned: make(map[string]interface{}),
+		ds: make(map[core.MetadataKey]interface{}),
 	}
 }
 
@@ -88,20 +78,13 @@ func (m *memoryThreadMetadata) GetBytes(t thread.ID, key string) (*[]byte, error
 func (m *memoryThreadMetadata) putValue(t thread.ID, key string, val interface{}) {
 	m.dslock.Lock()
 	defer m.dslock.Unlock()
-	if vals, ok := val.(string); ok && internKeys[key] {
-		if interned, ok := m.interned[vals]; ok {
-			val = interned
-		} else {
-			m.interned[vals] = val
-		}
-	}
-	m.ds[metakey{t, key}] = val
+	m.ds[core.MetadataKey{T: t, K: key}] = val
 }
 
 func (m *memoryThreadMetadata) getValue(t thread.ID, key string) interface{} {
 	m.dslock.RLock()
 	defer m.dslock.RUnlock()
-	if v, ok := m.ds[metakey{t, key}]; ok {
+	if v, ok := m.ds[core.MetadataKey{T: t, K: key}]; ok {
 		return v
 	}
 	return nil
@@ -111,9 +94,75 @@ func (m *memoryThreadMetadata) ClearMetadata(t thread.ID) error {
 	m.dslock.Lock()
 	defer m.dslock.Unlock()
 	for k := range m.ds {
-		if k.id.Equals(t) {
+		if k.T.Equals(t) {
 			delete(m.ds, k)
 		}
 	}
+	return nil
+}
+
+func (m *memoryThreadMetadata) DumpMeta() (core.DumpMetadata, error) {
+	m.dslock.RLock()
+	defer m.dslock.RUnlock()
+
+	var (
+		dump    core.DumpMetadata
+		vInt64  = make(map[core.MetadataKey]int64)
+		vBool   = make(map[core.MetadataKey]bool)
+		vString = make(map[core.MetadataKey]string)
+		vBytes  = make(map[core.MetadataKey][]byte)
+	)
+
+	for mk, value := range m.ds {
+		switch v := value.(type) {
+		case bool:
+			vBool[mk] = v
+		case int64:
+			vInt64[mk] = v
+		case string:
+			vString[mk] = v
+		case []byte:
+			vBytes[mk] = v
+		default:
+			return dump, fmt.Errorf("unsupported value type %T, key: %v, value: %v", value, mk, value)
+		}
+	}
+
+	dump.Data.Bool = vBool
+	dump.Data.Int64 = vInt64
+	dump.Data.String = vString
+	dump.Data.Bytes = vBytes
+	return dump, nil
+}
+
+func (m *memoryThreadMetadata) RestoreMeta(dump core.DumpMetadata) error {
+	var dataLen = len(dump.Data.Bool) +
+		len(dump.Data.Int64) +
+		len(dump.Data.String) +
+		len(dump.Data.Bytes)
+	if dataLen == 0 {
+		return core.ErrEmptyDump
+	}
+
+	m.dslock.Lock()
+	defer m.dslock.RUnlock()
+
+	// clear local data
+	m.ds = make(map[core.MetadataKey]interface{}, dataLen)
+
+	// replace with dump
+	for mk, val := range dump.Data.Bool {
+		m.ds[mk] = val
+	}
+	for mk, val := range dump.Data.Int64 {
+		m.ds[mk] = val
+	}
+	for mk, val := range dump.Data.String {
+		m.ds[mk] = val
+	}
+	for mk, val := range dump.Data.Bytes {
+		m.ds[mk] = val
+	}
+
 	return nil
 }

--- a/logstore/lstoremem/metadata.go
+++ b/logstore/lstoremem/metadata.go
@@ -140,7 +140,7 @@ func (m *memoryThreadMetadata) RestoreMeta(dump core.DumpMetadata) error {
 		len(dump.Data.Int64) +
 		len(dump.Data.String) +
 		len(dump.Data.Bytes)
-	if dataLen == 0 {
+	if !AllowEmptyRestore && dataLen == 0 {
 		return core.ErrEmptyDump
 	}
 

--- a/test/addr_book_suite.go
+++ b/test/addr_book_suite.go
@@ -392,21 +392,6 @@ func testExportAddressBook(ab core.AddrBook) func(*testing.T) {
 	return func(t *testing.T) {
 		tid := thread.NewIDV1(thread.Raw, 24)
 
-		t.Run("restore from empty dump", func(t *testing.T) {
-			ids := GeneratePeerIDs(2)
-			addrs := GenerateAddrs(2)
-
-			check(t, ab.AddAddr(tid, ids[0], addrs[0], time.Hour))
-			check(t, ab.AddAddr(tid, ids[1], addrs[1], time.Hour))
-
-			if err := ab.RestoreAddrs(core.DumpAddrBook{Data: nil}); err == nil {
-				t.Fatal("expected error restoring from the empty dump")
-			}
-
-			AssertAddressesEqual(t, addrs[:1], checkedAddrs(t, ab, tid, ids[0]))
-			AssertAddressesEqual(t, addrs[1:], checkedAddrs(t, ab, tid, ids[1]))
-		})
-
 		t.Run("dump and restore", func(t *testing.T) {
 			ids := GeneratePeerIDs(2)
 			addrs := GenerateAddrs(2)

--- a/test/headbook_suite.go
+++ b/test/headbook_suite.go
@@ -39,40 +39,30 @@ func HeadBookTest(t *testing.T, factory HeadBookFactory) {
 
 func testHeadBookAddHeads(hb core.HeadBook) func(t *testing.T) {
 	return func(t *testing.T) {
-		tid := thread.NewIDV1(thread.Raw, 24)
+		var (
+			numLogs   = 2
+			numHeads  = 3
+			tid, logs = genHeads(numLogs, numHeads)
+		)
 
-		_, pub, _ := pt.RandTestKeyPair(crypto.RSA, crypto.MinRsaKeyBits)
-		p, _ := peer.IDFromPublicKey(pub)
+		for lid, heads := range logs {
+			if stored, err := hb.Heads(tid, lid); err != nil || len(stored) > 0 {
+				t.Error("expected heads to be empty on init without errors")
+			}
 
-		if heads, err := hb.Heads(tid, p); err != nil || len(heads) > 0 {
-			t.Error("expected heads to be empty on init without errors")
-		}
-
-		heads := make([]cid.Cid, 0)
-		for i := 0; i < 2; i++ {
-			hash, _ := mh.Encode([]byte("foo"+strconv.Itoa(i)), mh.SHA2_256)
-			head := cid.NewCidV1(cid.DagCBOR, hash)
-
-			if err := hb.AddHeads(tid, p, []cid.Cid{head}); err != nil {
+			if err := hb.AddHeads(tid, lid, heads); err != nil {
 				t.Fatalf("error when adding heads: %v", err)
 			}
-			heads = append(heads, head)
 		}
 
-		hbHeads, err := hb.Heads(tid, p)
-		if err != nil {
-			t.Fatalf("error while getting heads: %v", err)
-		}
-		for _, h := range heads {
-			var found bool
-			for _, b := range hbHeads {
-				if b == h {
-					found = true
-					break
-				}
+		for lid, expected := range logs {
+			heads, err := hb.Heads(tid, lid)
+			if err != nil {
+				t.Fatalf("error while getting heads: %v", err)
 			}
-			if !found {
-				t.Errorf("head %s not found in book", h.String())
+
+			if !equalHeads(expected, heads) {
+				t.Fatalf("heads not equal, expected: %v, actual: %v", expected, heads)
 			}
 		}
 	}
@@ -80,39 +70,78 @@ func testHeadBookAddHeads(hb core.HeadBook) func(t *testing.T) {
 
 func testHeadBookSetHeads(hb core.HeadBook) func(t *testing.T) {
 	return func(t *testing.T) {
-		tid := thread.NewIDV1(thread.Raw, 24)
+		var (
+			numLogs   = 2
+			numHeads  = 3
+			tid, logs = genHeads(numLogs, numHeads)
+		)
 
-		_, pub, _ := pt.RandTestKeyPair(crypto.RSA, crypto.MinRsaKeyBits)
-		p, _ := peer.IDFromPublicKey(pub)
-
-		if heads, err := hb.Heads(tid, p); err != nil || len(heads) > 0 {
-			t.Error("expected heads to be empty on init without errors")
-		}
-
-		heads := make([]cid.Cid, 0)
-		for i := 0; i < 2; i++ {
-			hash, _ := mh.Encode([]byte("foo"+strconv.Itoa(i)), mh.SHA2_256)
-			head := cid.NewCidV1(cid.DagCBOR, hash)
-			heads = append(heads, head)
-		}
-		if err := hb.SetHeads(tid, p, heads); err != nil {
-			t.Fatalf("error when setting heads: %v", err)
-		}
-
-		hbHeads, err := hb.Heads(tid, p)
-		if err != nil {
-			t.Fatalf("error when getting heads: %v", err)
-		}
-		for _, h := range heads {
-			var found bool
-			for _, b := range hbHeads {
-				if b == h {
-					found = true
-					break
-				}
+		for lid, heads := range logs {
+			if stored, err := hb.Heads(tid, lid); err != nil || len(stored) > 0 {
+				t.Error("expected heads to be empty on init without errors")
 			}
-			if !found {
-				t.Errorf("head %s not found in book", h.String())
+
+			if err := hb.SetHeads(tid, lid, heads); err != nil {
+				t.Fatalf("error when adding heads: %v", err)
+			}
+		}
+
+		for lid, expected := range logs {
+			heads, err := hb.Heads(tid, lid)
+			if err != nil {
+				t.Fatalf("error while getting heads: %v", err)
+			}
+
+			if !equalHeads(expected, heads) {
+				t.Fatalf("heads not equal, expected: %v, actual: %v", expected, heads)
+			}
+		}
+	}
+}
+
+func testHeadBookClearHeads(hb core.HeadBook) func(t *testing.T) {
+	return func(t *testing.T) {
+		var (
+			numLogs   = 2
+			numHeads  = 2
+			tid, logs = genHeads(numLogs, numHeads)
+		)
+
+		for lid, heads := range logs {
+			if stored, err := hb.Heads(tid, lid); err != nil || len(stored) > 0 {
+				t.Error("expected heads to be empty on init without errors")
+			}
+
+			if err := hb.AddHeads(tid, lid, heads); err != nil {
+				t.Fatalf("error when adding heads: %v", err)
+			}
+		}
+
+		for lid, expected := range logs {
+			heads, err := hb.Heads(tid, lid)
+			if err != nil {
+				t.Fatalf("error while getting heads: %v", err)
+			}
+
+			if !equalHeads(expected, heads) {
+				t.Fatalf("heads not equal, expected: %v, actual: %v", expected, heads)
+			}
+		}
+
+		for lid := range logs {
+			if err := hb.ClearHeads(tid, lid); err != nil {
+				t.Fatalf("error when clearing heads: %v", err)
+			}
+		}
+
+		for lid := range logs {
+			heads, err := hb.Heads(tid, lid)
+			if err != nil {
+				t.Fatalf("error while getting heads: %v", err)
+			}
+
+			if len(heads) > 0 {
+				t.Fatalf("heads not empty after clear")
 			}
 		}
 	}
@@ -189,99 +218,115 @@ func BenchmarkHeadBook(b *testing.B, factory HeadBookFactory) {
 
 func benchmarkHeads(hb core.HeadBook) func(*testing.B) {
 	return func(b *testing.B) {
-		tid := thread.NewIDV1(thread.Raw, 24)
+		var (
+			numLogs   = 1
+			numHeads  = 1
+			tid, logs = genHeads(numLogs, numHeads)
+		)
 
-		_, pub, err := pt.RandTestKeyPair(crypto.RSA, crypto.MinRsaKeyBits)
-		if err != nil {
-			b.Error(err)
+		for lid, heads := range logs {
+			_ = hb.AddHeads(tid, lid, heads)
 		}
-
-		id, err := peer.IDFromPublicKey(pub)
-		if err != nil {
-			b.Error(err)
-		}
-
-		hash, _ := mh.Encode([]byte("foo"), mh.SHA2_256)
-		head := cid.NewCidV1(cid.DagCBOR, hash)
-
-		_ = hb.AddHead(tid, id, head)
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			_, _ = hb.Heads(tid, id)
+			for lid := range logs {
+				_, _ = hb.Heads(tid, lid)
+			}
 		}
 	}
 }
 
 func benchmarkAddHeads(hb core.HeadBook) func(*testing.B) {
 	return func(b *testing.B) {
-		tid := thread.NewIDV1(thread.Raw, 24)
-
-		_, pub, err := pt.RandTestKeyPair(crypto.RSA, crypto.MinRsaKeyBits)
-		if err != nil {
-			b.Error(err)
-		}
-
-		id, err := peer.IDFromPublicKey(pub)
-		if err != nil {
-			b.Error(err)
-		}
-
-		hash, _ := mh.Encode([]byte("foo"), mh.SHA2_256)
-		head := cid.NewCidV1(cid.DagCBOR, hash)
+		var (
+			numLogs   = 1
+			numHeads  = 1
+			tid, logs = genHeads(numLogs, numHeads)
+		)
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			_ = hb.AddHeads(tid, id, []cid.Cid{head})
+			for lid, heads := range logs {
+				_ = hb.AddHeads(tid, lid, heads)
+			}
 		}
 	}
 }
 
 func benchmarkSetHeads(hb core.HeadBook) func(*testing.B) {
 	return func(b *testing.B) {
-		tid := thread.NewIDV1(thread.Raw, 24)
-
-		_, pub, err := pt.RandTestKeyPair(crypto.RSA, crypto.MinRsaKeyBits)
-		if err != nil {
-			b.Error(err)
-		}
-
-		id, err := peer.IDFromPublicKey(pub)
-		if err != nil {
-			b.Error(err)
-		}
-
-		hash, _ := mh.Encode([]byte("foo"), mh.SHA2_256)
-		head := cid.NewCidV1(cid.DagCBOR, hash)
+		var (
+			numLogs   = 1
+			numHeads  = 1
+			tid, logs = genHeads(numLogs, numHeads)
+		)
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			_ = hb.SetHeads(tid, id, []cid.Cid{head})
+			for lid, heads := range logs {
+				_ = hb.SetHeads(tid, lid, heads)
+			}
 		}
 	}
 }
 
 func benchmarkClearHeads(hb core.HeadBook) func(*testing.B) {
 	return func(b *testing.B) {
-		tid := thread.NewIDV1(thread.Raw, 24)
+		var (
+			numLogs   = 1
+			numHeads  = 1
+			tid, logs = genHeads(numLogs, numHeads)
+		)
 
-		_, pub, err := pt.RandTestKeyPair(crypto.RSA, crypto.MinRsaKeyBits)
-		if err != nil {
-			b.Error(err)
+		for lid, heads := range logs {
+			_ = hb.SetHeads(tid, lid, heads)
 		}
-
-		id, err := peer.IDFromPublicKey(pub)
-		if err != nil {
-			b.Error(err)
-		}
-
-		hash, _ := mh.Encode([]byte("foo"), mh.SHA2_256)
-		head := cid.NewCidV1(cid.DagCBOR, hash)
-		_ = hb.SetHeads(tid, id, []cid.Cid{head})
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			_ = hb.ClearHeads(tid, id)
+			for lid := range logs {
+				_ = hb.ClearHeads(tid, lid)
+			}
 		}
 	}
+}
+
+func genHeads(numLogs, numHeads int) (thread.ID, map[peer.ID][]cid.Cid) {
+	var (
+		logs = make(map[peer.ID][]cid.Cid)
+		tid  = thread.NewIDV1(thread.Raw, 32)
+	)
+
+	for i := 0; i < numLogs; i++ {
+		_, pub, _ := pt.RandTestKeyPair(crypto.RSA, crypto.MinRsaKeyBits)
+		lid, _ := peer.IDFromPublicKey(pub)
+
+		heads := make([]cid.Cid, numHeads)
+		for j := 0; j < numHeads; j++ {
+			hash, _ := mh.Encode([]byte("h:"+strconv.Itoa(i)+":"+strconv.Itoa(j)), mh.SHA2_256)
+			heads[j] = cid.NewCidV1(cid.DagCBOR, hash)
+		}
+
+		logs[lid] = heads
+	}
+
+	return tid, logs
+}
+
+func equalHeads(h1, h2 []cid.Cid) bool {
+	if len(h1) != len(h2) {
+		return false
+	}
+
+	sort.Slice(h1, func(i, j int) bool { return h1[i].String() < h1[j].String() })
+	sort.Slice(h2, func(i, j int) bool { return h2[i].String() < h2[j].String() })
+
+	for i := 0; i < len(h1); i++ {
+		if !h1[i].Equals(h2[i]) {
+			return false
+		}
+	}
+
+	return true
 }

--- a/test/headbook_suite.go
+++ b/test/headbook_suite.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"bytes"
 	"sort"
 	"strconv"
 	"testing"
@@ -155,7 +154,7 @@ func testHeadBookExport(hb core.HeadBook) func(t *testing.T) {
 			numLogs   = 2
 			numHeads  = 3
 			tid, logs = genHeads(numLogs, numHeads)
-			buffer    bytes.Buffer
+			//buffer    bytes.Buffer
 		)
 
 		for lid, heads := range logs {
@@ -168,7 +167,8 @@ func testHeadBookExport(hb core.HeadBook) func(t *testing.T) {
 			}
 		}
 
-		if err := hb.Dump(&buffer); err != nil {
+		dump, err := hb.DumpHeads()
+		if err != nil {
 			t.Fatalf("error dumping headbook: %v", err)
 		}
 
@@ -179,7 +179,7 @@ func testHeadBookExport(hb core.HeadBook) func(t *testing.T) {
 			}
 		}
 
-		if err := hb.Restore(&buffer); err != nil {
+		if err := hb.RestoreHeads(dump); err != nil {
 			t.Fatalf("error restoring headbook: %v", err)
 		}
 

--- a/test/headbook_suite.go
+++ b/test/headbook_suite.go
@@ -154,7 +154,6 @@ func testHeadBookExport(hb core.HeadBook) func(t *testing.T) {
 			numLogs   = 2
 			numHeads  = 3
 			tid, logs = genHeads(numLogs, numHeads)
-			//buffer    bytes.Buffer
 		)
 
 		for lid, heads := range logs {

--- a/util/finalizer.go
+++ b/util/finalizer.go
@@ -1,0 +1,44 @@
+package util
+
+import (
+	"context"
+	"io"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+// Finalizer collects resources for convenient cleanup.
+func NewFinalizer() *Finalizer {
+	return &Finalizer{}
+}
+
+type Finalizer struct {
+	resources []io.Closer
+}
+
+func (r *Finalizer) Add(cs ...io.Closer) {
+	r.resources = append(r.resources, cs...)
+}
+
+func (r *Finalizer) Cleanup(err error) error {
+	// release resources in a reverse order
+	for i := len(r.resources) - 1; i >= 0; i-- {
+		err = multierror.Append(r.resources[i].Close())
+	}
+
+	return err.(*multierror.Error).ErrorOrNil()
+}
+
+// Transform context cancellation function to be used with finalizer.
+func NewContextCloser(cancel context.CancelFunc) io.Closer {
+	return &ContextCloser{cf: cancel}
+}
+
+type ContextCloser struct {
+	cf context.CancelFunc
+}
+
+func (cc ContextCloser) Close() error {
+	cc.cf()
+	return nil
+}


### PR DESCRIPTION
Currently logstore requests are skewed towards the reads, while some retrievals (notably `GetThread`) are pretty expensive, requiring multiple subrequests of logstore components that goes through the series of mutexes preserving data consistency.
So we implemented a new hybrid model of logstore, which is both persistent and enables fast reads. Basically it's just a write-through in-memory cache backed by a datastore for persistency. We combined two existing implementations (lstoreds + lstoremem), such that all reads goes into in-memory store only, and writes are performed in both.
Resulting hybrid model makes request processing order of magnitude faster with a tradeoff of slower writes and increased memory consumption as we're keeping all the data in memory. Given that such a setting is not universal but would be useful for higher-rank nodes, it can be enabled with an option and lstoreds remains the default one.
As a useful side effect, now we also get export/import capabilities for all the different logstore implementations. It makes implementation of components and data exchange easier, enables dumping data for analysis etc.
