### PR TITLE
Thread edge proposal

### DIFF
--- a/core/logstore/logstore.go
+++ b/core/logstore/logstore.go
@@ -203,6 +203,9 @@ type HeadBook interface {
 	// ClearHeads deletes the head entry for a log.
 	ClearHeads(thread.ID, peer.ID) error
 
+	// ThreadEdge returns deterministic hash of all heads of a given thread.
+	ThreadEdge(t thread.ID) (uint64, error)
+
 	// DumpHeads packs entire headbook into the tree.
 	DumpHeads() (DumpHeadBook, error)
 

--- a/core/logstore/logstore.go
+++ b/core/logstore/logstore.go
@@ -203,8 +203,8 @@ type HeadBook interface {
 	// ClearHeads deletes the head entry for a log.
 	ClearHeads(thread.ID, peer.ID) error
 
-	// ThreadEdge returns deterministic hash of all heads of a given thread.
-	ThreadEdge(t thread.ID) (uint64, error)
+	// HeadsEdge returns deterministic hash of all heads of a given thread.
+	HeadsEdge(t thread.ID) (uint64, error)
 
 	// DumpHeads packs entire headbook into the tree.
 	DumpHeads() (DumpHeadBook, error)

--- a/db/collection_test.go
+++ b/db/collection_test.go
@@ -872,6 +872,9 @@ func TestModifiedSince(t *testing.T) {
 		})
 		checkErr(t, err)
 
+		// let write transaction propagate
+		time.Sleep(10 * time.Millisecond)
+
 		var instance []byte
 		err = c.ReadTxn(func(txn *Txn) (err error) {
 			instance, err = txn.FindByID(res[0])
@@ -891,7 +894,7 @@ func TestModifiedSince(t *testing.T) {
 			t.Fatalf("should have had %d modified instance", 1)
 		}
 		if mods[0] != p.ID {
-			t.Fatalf("should have modfied id %s", p.ID)
+			t.Fatalf("should have modified id %s", p.ID)
 		}
 	})
 	t.Run("WithCreateSaveAndDelete", func(t *testing.T) {
@@ -936,6 +939,9 @@ func TestModifiedSince(t *testing.T) {
 			return
 		})
 		checkErr(t, err)
+
+		// let write transactions propagate
+		time.Sleep(10 * time.Millisecond)
 
 		var mods []core.InstanceID
 		err = c.ReadTxn(func(txn *Txn) (err error) {

--- a/logstore/lstoreds/headbook.go
+++ b/logstore/lstoreds/headbook.go
@@ -24,10 +24,11 @@ var (
 	// /thread/heads/<base32 thread id no padding>/<base32 peer id no padding>
 	hbBase = ds.NewKey("/thread/heads")
 
-	// Thread edges are stored in db key pattern:
-	// /thread/heads/edge/<base32 thread id no padding>>
-	hbEdge               = hbBase.ChildString("/edge")
-	_      core.HeadBook = (*dsHeadBook)(nil)
+	// Heads edges are stored in db key pattern:
+	// /thread/heads:edge/<base32 thread id no padding>>
+	hbEdge = ds.NewKey("/thread/heads:edge")
+
+	_ core.HeadBook = (*dsHeadBook)(nil)
 )
 
 // NewHeadBook returns a new HeadBook backed by a datastore.
@@ -169,7 +170,7 @@ func (hb *dsHeadBook) HeadsEdge(tid thread.ID) (uint64, error) {
 }
 
 func (hb *dsHeadBook) getEdge(txn ds.Txn, tid thread.ID) (uint64, error) {
-	var key = dsThreadKey(tid, hbBase.Child(hbEdge))
+	var key = dsThreadKey(tid, hbEdge)
 	if v, err := txn.Get(key); err == nil {
 		return binary.BigEndian.Uint64(v), nil
 	} else if err != ds.ErrNotFound {
@@ -206,7 +207,7 @@ func (hb *dsHeadBook) getEdge(txn ds.Txn, tid thread.ID) (uint64, error) {
 }
 
 func (hb *dsHeadBook) invalidateEdge(txn ds.Txn, tid thread.ID) error {
-	var key = dsThreadKey(tid, hbBase.Child(hbEdge))
+	var key = dsThreadKey(tid, hbEdge)
 	return txn.Delete(key)
 }
 

--- a/logstore/lstoreds/headbook.go
+++ b/logstore/lstoreds/headbook.go
@@ -155,7 +155,7 @@ func (hb *dsHeadBook) ClearHeads(t thread.ID, p peer.ID) error {
 	return txn.Commit()
 }
 
-func (hb *dsHeadBook) ThreadEdge(tid thread.ID) (uint64, error) {
+func (hb *dsHeadBook) HeadsEdge(tid thread.ID) (uint64, error) {
 	txn, err := hb.ds.NewTransaction(false)
 	if err != nil {
 		return 0, fmt.Errorf("error when creating txn in datastore: %w", err)
@@ -199,7 +199,7 @@ func (hb *dsHeadBook) getEdge(txn ds.Txn, tid thread.ID) (uint64, error) {
 
 	var (
 		buff [8]byte
-		edge = util.ComputeThreadEdge(hs)
+		edge = util.ComputeHeadsEdge(hs)
 	)
 	binary.BigEndian.PutUint64(buff[:], edge)
 	return edge, txn.Put(key, buff[:])

--- a/logstore/lstoreds/headbook.go
+++ b/logstore/lstoreds/headbook.go
@@ -193,6 +193,9 @@ func (hb *dsHeadBook) getEdge(txn ds.Txn, tid thread.ID) (uint64, error) {
 			hs = append(hs, util.LogHead{Head: heads[i], LogID: lid})
 		}
 	}
+	if len(hs) == 0 {
+		return 0, core.ErrThreadNotFound
+	}
 
 	var (
 		buff [8]byte

--- a/logstore/lstoreds/headbook.go
+++ b/logstore/lstoreds/headbook.go
@@ -297,7 +297,7 @@ func (hb *dsHeadBook) decodeHeadEntry(
 	}
 	if withHeads {
 		var hr pb.HeadBookRecord
-		if err := proto.Unmarshal(entry.Value, &hr); err != nil {
+		if err = proto.Unmarshal(entry.Value, &hr); err != nil {
 			err = fmt.Errorf("cannot decode headbook record: %w", err)
 			return
 		}

--- a/logstore/lstorehybrid/logstore.go
+++ b/logstore/lstorehybrid/logstore.go
@@ -278,8 +278,8 @@ func (l *lstore) ClearHeads(tid thread.ID, lid peer.ID) error {
 	return l.inMem.ClearHeads(tid, lid)
 }
 
-func (l *lstore) ThreadEdge(tid thread.ID) (uint64, error) {
-	return l.inMem.ThreadEdge(tid)
+func (l *lstore) HeadsEdge(tid thread.ID) (uint64, error) {
+	return l.inMem.HeadsEdge(tid)
 }
 
 func (l *lstore) Threads() (thread.IDSlice, error) {

--- a/logstore/lstorehybrid/logstore.go
+++ b/logstore/lstorehybrid/logstore.go
@@ -278,6 +278,10 @@ func (l *lstore) ClearHeads(tid thread.ID, lid peer.ID) error {
 	return l.inMem.ClearHeads(tid, lid)
 }
 
+func (l *lstore) ThreadEdge(tid thread.ID) (uint64, error) {
+	return l.inMem.ThreadEdge(tid)
+}
+
 func (l *lstore) Threads() (thread.IDSlice, error) {
 	return l.inMem.Threads()
 }

--- a/logstore/lstoremem/headbook.go
+++ b/logstore/lstoremem/headbook.go
@@ -53,7 +53,7 @@ func (mhb *memoryHeadBook) AddHead(t thread.ID, p peer.ID, head cid.Cid) error {
 func (mhb *memoryHeadBook) AddHeads(t thread.ID, p peer.ID, heads []cid.Cid) error {
 	mhb.Lock()
 	defer mhb.Unlock()
-	defer mhb.updateThreadEdge(t)
+	defer mhb.updateEdge(t)
 
 	hmap := mhb.getHeads(t, p, true)
 	for _, h := range heads {
@@ -73,7 +73,7 @@ func (mhb *memoryHeadBook) SetHead(t thread.ID, p peer.ID, head cid.Cid) error {
 func (mhb *memoryHeadBook) SetHeads(t thread.ID, p peer.ID, heads []cid.Cid) error {
 	mhb.Lock()
 	defer mhb.Unlock()
-	defer mhb.updateThreadEdge(t)
+	defer mhb.updateEdge(t)
 
 	var hset = make(map[cid.Cid]struct{}, len(heads))
 	for _, h := range heads {
@@ -122,12 +122,12 @@ func (mhb *memoryHeadBook) ClearHeads(t thread.ID, p peer.ID) error {
 	if len(lset) == 0 {
 		delete(mhb.threads, t)
 	} else {
-		mhb.updateThreadEdge(t)
+		mhb.updateEdge(t)
 	}
 	return nil
 }
 
-func (mhb *memoryHeadBook) ThreadEdge(t thread.ID) (uint64, error) {
+func (mhb *memoryHeadBook) HeadsEdge(t thread.ID) (uint64, error) {
 	mhb.RLock()
 	defer mhb.RUnlock()
 
@@ -139,7 +139,7 @@ func (mhb *memoryHeadBook) ThreadEdge(t thread.ID) (uint64, error) {
 	return lset.edge, nil
 }
 
-func (mhb *memoryHeadBook) updateThreadEdge(t thread.ID) {
+func (mhb *memoryHeadBook) updateEdge(t thread.ID) {
 	// invariant: requested thread exist
 	var (
 		lset  = mhb.threads[t]
@@ -153,7 +153,7 @@ func (mhb *memoryHeadBook) updateThreadEdge(t thread.ID) {
 			})
 		}
 	}
-	lset.edge = util.ComputeThreadEdge(heads)
+	lset.edge = util.ComputeHeadsEdge(heads)
 	mhb.threads[t] = lset
 }
 
@@ -201,7 +201,7 @@ func (mhb *memoryHeadBook) RestoreHeads(dump core.DumpHeadBook) error {
 			heads map[peer.ID]map[cid.Cid]struct{}
 			edge  uint64
 		}{heads: lm}
-		mhb.updateThreadEdge(tid)
+		mhb.updateEdge(tid)
 	}
 
 	return nil

--- a/logstore/lstoremem/headbook.go
+++ b/logstore/lstoremem/headbook.go
@@ -7,28 +7,42 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 	core "github.com/textileio/go-threads/core/logstore"
 	"github.com/textileio/go-threads/core/thread"
+	"github.com/textileio/go-threads/util"
 )
 
 type memoryHeadBook struct {
 	sync.RWMutex
-
-	heads map[thread.ID]map[peer.ID]map[cid.Cid]struct{}
+	threads map[thread.ID]struct {
+		heads map[peer.ID]map[cid.Cid]struct{}
+		edge  uint64
+	}
 }
 
-func (mhb *memoryHeadBook) getHeads(t thread.ID, p peer.ID) (map[cid.Cid]struct{}, bool) {
-	lmap, found := mhb.heads[t]
-	if lmap == nil {
-		return nil, found
+func (mhb *memoryHeadBook) getHeads(t thread.ID, p peer.ID, createEmpty bool) map[cid.Cid]struct{} {
+	lmap := mhb.threads[t]
+	if lmap.heads == nil {
+		if !createEmpty {
+			return nil
+		}
+		lmap.heads = make(map[peer.ID]map[cid.Cid]struct{}, 1)
+		mhb.threads[t] = lmap
 	}
-	hmap, found := lmap[p]
-	return hmap, found
+	hmap := lmap.heads[p]
+	if hmap == nil && createEmpty {
+		hmap = make(map[cid.Cid]struct{})
+		lmap.heads[p] = hmap
+	}
+	return hmap
 }
 
 var _ core.HeadBook = (*memoryHeadBook)(nil)
 
 func NewHeadBook() core.HeadBook {
 	return &memoryHeadBook{
-		heads: map[thread.ID]map[peer.ID]map[cid.Cid]struct{}{},
+		threads: make(map[thread.ID]struct {
+			heads map[peer.ID]map[cid.Cid]struct{}
+			edge  uint64
+		}),
 	}
 }
 
@@ -39,16 +53,9 @@ func (mhb *memoryHeadBook) AddHead(t thread.ID, p peer.ID, head cid.Cid) error {
 func (mhb *memoryHeadBook) AddHeads(t thread.ID, p peer.ID, heads []cid.Cid) error {
 	mhb.Lock()
 	defer mhb.Unlock()
+	defer mhb.updateThreadEdge(t)
 
-	hmap, _ := mhb.getHeads(t, p)
-	if hmap == nil {
-		if mhb.heads[t] == nil {
-			mhb.heads[t] = make(map[peer.ID]map[cid.Cid]struct{}, 1)
-		}
-		hmap = make(map[cid.Cid]struct{}, len(heads))
-		mhb.heads[t][p] = hmap
-	}
-
+	hmap := mhb.getHeads(t, p, true)
 	for _, h := range heads {
 		if !h.Defined() {
 			log.Warnf("was passed nil head for %s", p)
@@ -66,23 +73,24 @@ func (mhb *memoryHeadBook) SetHead(t thread.ID, p peer.ID, head cid.Cid) error {
 func (mhb *memoryHeadBook) SetHeads(t thread.ID, p peer.ID, heads []cid.Cid) error {
 	mhb.Lock()
 	defer mhb.Unlock()
+	defer mhb.updateThreadEdge(t)
 
-	hmap, _ := mhb.getHeads(t, p)
-	if hmap == nil {
-		if mhb.heads[t] == nil {
-			mhb.heads[t] = make(map[peer.ID]map[cid.Cid]struct{}, 1)
-		}
-	}
-	hmap = make(map[cid.Cid]struct{}, len(heads))
-	mhb.heads[t][p] = hmap
-
+	var hset = make(map[cid.Cid]struct{}, len(heads))
 	for _, h := range heads {
 		if !h.Defined() {
 			log.Warnf("was passed nil head for %s", p)
 			continue
 		}
-		hmap[h] = struct{}{}
+		hset[h] = struct{}{}
 	}
+	// replace heads
+	if mhb.threads[t].heads == nil {
+		mhb.threads[t] = struct {
+			heads map[peer.ID]map[cid.Cid]struct{}
+			edge  uint64
+		}{heads: make(map[peer.ID]map[cid.Cid]struct{})}
+	}
+	mhb.threads[t].heads[p] = hset
 	return nil
 }
 
@@ -90,12 +98,13 @@ func (mhb *memoryHeadBook) Heads(t thread.ID, p peer.ID) ([]cid.Cid, error) {
 	mhb.RLock()
 	defer mhb.RUnlock()
 
-	var heads []cid.Cid
-	hmap, _ := mhb.getHeads(t, p)
-	if hmap == nil {
-		return heads, nil
+	hset := mhb.getHeads(t, p, false)
+	if hset == nil {
+		return nil, nil
 	}
-	for h := range hmap {
+
+	var heads = make([]cid.Cid, 0, len(hset))
+	for h := range hset {
 		heads = append(heads, h)
 	}
 	return heads, nil
@@ -105,24 +114,57 @@ func (mhb *memoryHeadBook) ClearHeads(t thread.ID, p peer.ID) error {
 	mhb.Lock()
 	defer mhb.Unlock()
 
-	lmap := mhb.heads[t]
-	if lmap != nil {
-		delete(lmap, p)
-		if len(lmap) == 0 {
-			delete(mhb.heads, t)
-		}
+	var lset = mhb.threads[t].heads
+	if lset == nil {
+		return nil
+	}
+	delete(lset, p)
+	if len(lset) == 0 {
+		delete(mhb.threads, t)
+	} else {
+		mhb.updateThreadEdge(t)
 	}
 	return nil
 }
 
+func (mhb *memoryHeadBook) ThreadEdge(t thread.ID) (uint64, error) {
+	mhb.RLock()
+	defer mhb.RUnlock()
+
+	lset, found := mhb.threads[t]
+	if !found {
+		return 0, core.ErrThreadNotFound
+	}
+	// invariant: edge always precomputed for existing thread
+	return lset.edge, nil
+}
+
+func (mhb *memoryHeadBook) updateThreadEdge(t thread.ID) {
+	// invariant: requested thread exist
+	var (
+		lset  = mhb.threads[t]
+		heads = make([]util.LogHead, 0, len(lset.heads))
+	)
+	for lid, hs := range lset.heads {
+		for head := range hs {
+			heads = append(heads, util.LogHead{
+				LogID: lid,
+				Head:  head,
+			})
+		}
+	}
+	lset.edge = util.ComputeThreadEdge(heads)
+	mhb.threads[t] = lset
+}
+
 func (mhb *memoryHeadBook) DumpHeads() (core.DumpHeadBook, error) {
 	var dump = core.DumpHeadBook{
-		Data: make(map[thread.ID]map[peer.ID][]cid.Cid, len(mhb.heads)),
+		Data: make(map[thread.ID]map[peer.ID][]cid.Cid, len(mhb.threads)),
 	}
 
-	for tid, logs := range mhb.heads {
-		lm := make(map[peer.ID][]cid.Cid, len(logs))
-		for lid, hs := range logs {
+	for tid, lset := range mhb.threads {
+		lm := make(map[peer.ID][]cid.Cid, len(lset.heads))
+		for lid, hs := range lset.heads {
 			heads := make([]cid.Cid, 0, len(hs))
 			for head := range hs {
 				heads = append(heads, head)
@@ -140,7 +182,12 @@ func (mhb *memoryHeadBook) RestoreHeads(dump core.DumpHeadBook) error {
 		return core.ErrEmptyDump
 	}
 
-	var restored = make(map[thread.ID]map[peer.ID]map[cid.Cid]struct{}, len(dump.Data))
+	// reset stored
+	mhb.threads = make(map[thread.ID]struct {
+		heads map[peer.ID]map[cid.Cid]struct{}
+		edge  uint64
+	}, len(dump.Data))
+
 	for tid, logs := range dump.Data {
 		lm := make(map[peer.ID]map[cid.Cid]struct{}, len(logs))
 		for lid, hs := range logs {
@@ -150,9 +197,12 @@ func (mhb *memoryHeadBook) RestoreHeads(dump core.DumpHeadBook) error {
 			}
 			lm[lid] = hm
 		}
-		restored[tid] = lm
+		mhb.threads[tid] = struct {
+			heads map[peer.ID]map[cid.Cid]struct{}
+			edge  uint64
+		}{heads: lm}
+		mhb.updateThreadEdge(tid)
 	}
 
-	mhb.heads = restored
 	return nil
 }

--- a/net/server.go
+++ b/net/server.go
@@ -164,7 +164,7 @@ func (s *server) GetRecords(ctx context.Context, req *pb.GetRecordsRequest) (*pb
 	}
 
 	// fast check if requested offsets are equal with thread heads
-	if changed, err := s.threadChanged(req); err != nil {
+	if changed, err := s.headsChanged(req); err != nil {
 		return nil, err
 	} else if !changed {
 		return pbrecs, nil
@@ -274,17 +274,17 @@ func (s *server) checkServiceKey(id thread.ID, k *pb.ProtoKey) error {
 	return nil
 }
 
-// threadChanged determines if thread heads are different from the requested offsets.
-func (s *server) threadChanged(req *pb.GetRecordsRequest) (bool, error) {
+// headsChanged determines if thread heads are different from the requested offsets.
+func (s *server) headsChanged(req *pb.GetRecordsRequest) (bool, error) {
 	var reqHeads = make([]util.LogHead, len(req.Body.Logs))
 	for i, l := range req.Body.GetLogs() {
 		reqHeads[i] = util.LogHead{Head: l.Offset.Cid, LogID: l.LogID.ID}
 	}
-	var currEdge, err = s.net.store.ThreadEdge(req.Body.ThreadID.ID)
+	var currEdge, err = s.net.store.HeadsEdge(req.Body.ThreadID.ID)
 	if err != nil {
 		return false, err
 	}
-	return util.ComputeThreadEdge(reqHeads) != currEdge, nil
+	return util.ComputeHeadsEdge(reqHeads) != currEdge, nil
 }
 
 // verifyRequest verifies that the signature associated with a request is valid.

--- a/test/addr_book_suite.go
+++ b/test/addr_book_suite.go
@@ -125,8 +125,8 @@ func testAddAddress(ab core.AddrBook) func(*testing.T) {
 			// 1 second left
 			check(t, ab.AddAddrs(tid, id, addrs, 3*time.Second))
 			// 3 seconds left
-			time.Sleep(2 * time.Second)
-			// 1 seconds left.
+			time.Sleep(1 * time.Second)
+			// 2 seconds left.
 
 			// We still have the address.
 			AssertAddressesEqual(t, addrs, checkedAddrs(t, ab, tid, id))

--- a/test/headbook_suite.go
+++ b/test/headbook_suite.go
@@ -20,7 +20,7 @@ var headBookSuite = map[string]func(hb core.HeadBook) func(*testing.T){
 	"SetGetHeads": testHeadBookSetHeads,
 	"ClearHeads":  testHeadBookClearHeads,
 	"ExportHeads": testHeadBookExport,
-	"ThreadEdge":  testHeadBookThreadEdge,
+	"HeadsEdge":   testHeadBookEdge,
 }
 
 type HeadBookFactory func() (core.HeadBook, func())
@@ -150,7 +150,7 @@ func testHeadBookClearHeads(hb core.HeadBook) func(t *testing.T) {
 	}
 }
 
-func testHeadBookThreadEdge(hb core.HeadBook) func(t *testing.T) {
+func testHeadBookEdge(hb core.HeadBook) func(t *testing.T) {
 	return func(t *testing.T) {
 		var (
 			numLogs  = 3
@@ -176,7 +176,7 @@ func testHeadBookThreadEdge(hb core.HeadBook) func(t *testing.T) {
 						heads = append(heads, util.LogHead{LogID: lid, Head: c})
 					}
 				}
-				return util.ComputeThreadEdge(heads) == edge
+				return util.ComputeHeadsEdge(heads) == edge
 			}
 
 			// generate 3 sets of heads
@@ -184,7 +184,7 @@ func testHeadBookThreadEdge(hb core.HeadBook) func(t *testing.T) {
 			hSet1, hSet2, hSet3 = heads[0], heads[1], heads[2]
 		)
 
-		if _, err := hb.ThreadEdge(tid); err != core.ErrThreadNotFound {
+		if _, err := hb.HeadsEdge(tid); err != core.ErrThreadNotFound {
 			t.Error("expected to get error on retrieving non-existing thread's edge")
 		}
 		for lid, hs := range hSet1 {
@@ -196,7 +196,7 @@ func testHeadBookThreadEdge(hb core.HeadBook) func(t *testing.T) {
 			}
 		}
 
-		edge1, err := hb.ThreadEdge(tid)
+		edge1, err := hb.HeadsEdge(tid)
 		if err != nil {
 			t.Errorf("error while getting thread's edge: %v", err)
 		}
@@ -207,7 +207,7 @@ func testHeadBookThreadEdge(hb core.HeadBook) func(t *testing.T) {
 				t.Fatalf("error when adding heads: %v", err)
 			}
 		}
-		edge2, err := hb.ThreadEdge(tid)
+		edge2, err := hb.HeadsEdge(tid)
 		if err != nil {
 			t.Errorf("error while getting thread's edge: %v", err)
 		}
@@ -224,7 +224,7 @@ func testHeadBookThreadEdge(hb core.HeadBook) func(t *testing.T) {
 				t.Fatalf("error when adding heads: %v", err)
 			}
 		}
-		edge3, err := hb.ThreadEdge(tid)
+		edge3, err := hb.HeadsEdge(tid)
 		if err != nil {
 			t.Errorf("error while getting thread's edge: %v", err)
 		}

--- a/util/util.go
+++ b/util/util.go
@@ -205,7 +205,7 @@ type LogHead struct {
 	Head  cid.Cid
 }
 
-func ComputeThreadEdge(hs []LogHead) uint64 {
+func ComputeHeadsEdge(hs []LogHead) uint64 {
 	// sort heads for deterministic edge computation
 	sort.Slice(hs, func(i, j int) bool {
 		if hs[i].LogID == hs[j].LogID {


### PR DESCRIPTION
Hi folks, here is another improvement for GetRecords.

This time we propose a new concept: thread edge. Basically it's just a 64-bit deterministic hash of all heads in a thread. Using the edge values we can easily compare two states of the same thread and decide if they are equal without fetching all thread's information from the logstore. Such optimization at first should improve request processing time on a fast path for the frequent GetRecords requests.
As a follow-up: introducing thread edges enables implementing fast checks for thread changes without getting and sending thread information on both  communicating nodes (protocol extension in progress for now).
