### PR TITLE
Track real counts for limit and skip

### DIFF
--- a/db/index.go
+++ b/db/index.go
@@ -290,8 +290,10 @@ func newIterator(txn dse.TxnExt, baseKey ds.Key, q *Query) *iterator {
 	dsq := dse.QueryExt{
 		Query: query.Query{
 			Prefix: prefix.String(),
-			Limit:  q.Limit,
-			Offset: q.Skip,
+			// Pull out Skip and Limit here because we won't know ahead of time
+			// (due to readFilters) how many to skip/limit
+			// Limit:  q.Limit,
+			// Offset: q.Skip,
 		},
 	}
 	if q.Sort.FieldPath == idFieldName {

--- a/db/query.go
+++ b/db/query.go
@@ -314,6 +314,9 @@ func (t *Txn) Find(q *Query) ([][]byte, error) {
 		return nil, err
 	}
 	var values []MarshaledResult
+	// Use count to track real count of returned values taking into account
+	// read filter and any indexes etc in the query
+	var count = 0
 	for {
 		res, ok := iter.NextSync()
 		if !ok {
@@ -323,8 +326,12 @@ func (t *Txn) Find(q *Query) ([][]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		if res.Value != nil {
+		count++
+		if res.Value != nil && count > q.Skip {
 			values = append(values, res)
+		}
+		if count == q.Limit {
+			break
 		}
 	}
 

--- a/db/query_more_test.go
+++ b/db/query_more_test.go
@@ -89,6 +89,9 @@ var (
 
 		{name: "SortAllAscFloat", query: OrderBy("Meta.Rating"), resIdx: []int{0, 1, 2, 3, 4}, ordered: true},
 		{name: "SortAllDescFloat", query: OrderByDesc("Meta.Rating"), resIdx: []int{4, 3, 2, 1, 0}, ordered: true},
+
+		{name: "LimitTotalReadsOutside", query: Where("Meta.TotalReads").Gt(float64(100)).LimitTo(2), resIdx: []int{3, 4}},
+		{name: "LimitTotalReadsInside", query: Where("Meta.TotalReads").Lt(float64(100)).LimitTo(2), resIdx: []int{0, 1}},
 	}
 )
 


### PR DESCRIPTION
Applies Limit and Skip _after_ other conditions _and_ read filter have been applied. This leads to potentially slightly less efficient queries (because the child query engine can't handle the limits and skips directly), but provides more consistent and accurate/expected results. A test has been added that captures the issue presented in #458, plus a "regression" test was added to ensure we don't over-compensate.

Fixes #458.

Technically this is a bug fix, but it also changes how results are returned when applying limit and skip, so this might need to come with an appropriate version bump?