### PR TITLE
Fixes error when chaining skip and limit

### DIFF
--- a/db/query.go
+++ b/db/query.go
@@ -317,6 +317,7 @@ func (t *Txn) Find(q *Query) ([][]byte, error) {
 	// Use count to track real count of returned values taking into account
 	// read filter and any indexes etc in the query
 	var count = 0
+	offset := q.Limit + q.Skip
 	for {
 		res, ok := iter.NextSync()
 		if !ok {
@@ -330,7 +331,7 @@ func (t *Txn) Find(q *Query) ([][]byte, error) {
 		if res.Value != nil && count > q.Skip {
 			values = append(values, res)
 		}
-		if count == q.Limit {
+		if count == offset {
 			break
 		}
 	}

--- a/db/query_more_test.go
+++ b/db/query_more_test.go
@@ -92,6 +92,8 @@ var (
 
 		{name: "LimitTotalReadsOutside", query: Where("Meta.TotalReads").Gt(float64(100)).LimitTo(2), resIdx: []int{3, 4}},
 		{name: "LimitTotalReadsInside", query: Where("Meta.TotalReads").Lt(float64(100)).LimitTo(2), resIdx: []int{0, 1}},
+
+		{name: "LimitWithSkip", query: Where("Meta.TotalReads").Gt(float64(0)).SkipNum(1).LimitTo(3), resIdx: []int{1, 2, 3}},
 	}
 )
 


### PR DESCRIPTION
Fixes a simple error when skip and limit are chained, leading to what is essentially an offset. This also adds a test for this case. In addition to fixing an error, this PR makes the query more strict about what it "counts". It no longer counts instances that are set to nil by the read filter.