### PR TITLE
Total records limit in the GetRecords reply

### DIFF
--- a/net/server.go
+++ b/net/server.go
@@ -172,16 +172,24 @@ func (s *server) GetRecords(ctx context.Context, req *pb.GetRecordsRequest) (*pb
 	}
 	pbrecs.Logs = make([]*pb.GetRecordsReply_LogEntry, len(info.Logs))
 
+	var recordLimit = MaxPullLimit
 	for i, lg := range info.Logs {
-		var offset cid.Cid
-		var limit int
-		var pblg *pb.Log
+		var (
+			offset cid.Cid
+			limit  int
+			pblg   *pb.Log
+
+			// correct records-per-log limit
+			logsRemain     = len(info.Logs) - i
+			logRecordLimit = recordLimit / logsRemain
+		)
+
 		if opts, ok := reqd[lg.ID]; ok {
 			offset = opts.Offset.Cid
-			limit = int(opts.Limit)
+			limit = minInt(int(opts.Limit), logRecordLimit)
 		} else {
 			offset = cid.Undef
-			limit = MaxPullLimit
+			limit = logRecordLimit
 			pblg = logToProto(lg)
 		}
 		recs, err := s.net.getLocalRecords(ctx, req.Body.ThreadID.ID, lg.ID, offset, limit)
@@ -201,6 +209,9 @@ func (s *server) GetRecords(ctx context.Context, req *pb.GetRecordsRequest) (*pb
 			}
 		}
 		pbrecs.Logs[i] = entry
+
+		// update remaining records limit
+		recordLimit -= len(recs)
 
 		log.Debugf("sending %d records in log %s to %s", len(recs), lg.ID, pid)
 	}
@@ -324,4 +335,11 @@ func addrsFromProto(pa []pb.ProtoAddr) []ma.Multiaddr {
 		mas[i] = a.Multiaddr
 	}
 	return mas
+}
+
+func minInt(x, y int) int {
+	if x < y {
+		return x
+	}
+	return y
 }


### PR DESCRIPTION
Currently number of records returned in the `GetRecordsReply` is limited by a constant value for every log. However, if some thread contains large number of logs we can still hit on a gRPC's message size limit. Instead we can limit total number of records for all logs in the thread.