### PR TITLE
Exchange edges improvements

### DIFF
--- a/broadcast/broadcast_test.go
+++ b/broadcast/broadcast_test.go
@@ -11,7 +11,7 @@ import (
 const (
 	N       = 3
 	testStr = "Test"
-	timeout = time.Second * 2
+	timeout = time.Second * 4
 )
 
 type ListenFunc func(int, *Broadcaster, *sync.WaitGroup)

--- a/logstore/lstoreds/addr_book.go
+++ b/logstore/lstoreds/addr_book.go
@@ -258,7 +258,7 @@ func (ab *DsAddrBook) AddrsEdge(t thread.ID) (uint64, error) {
 		}
 	}
 	if len(as) == 0 {
-		return 0, core.ErrThreadNotFound
+		return EmptyEdgeValue, core.ErrThreadNotFound
 	}
 
 	var (

--- a/logstore/lstoreds/headbook.go
+++ b/logstore/lstoreds/headbook.go
@@ -207,7 +207,7 @@ func (hb *dsHeadBook) getEdge(tid thread.ID, key ds.Key) (uint64, error) {
 		}
 	}
 	if len(hs) == 0 {
-		return 0, core.ErrThreadNotFound
+		return EmptyEdgeValue, core.ErrThreadNotFound
 	}
 
 	var (

--- a/logstore/lstoreds/logstore.go
+++ b/logstore/lstoreds/logstore.go
@@ -16,6 +16,8 @@ import (
 // Define if storage will accept empty dumps.
 var AllowEmptyRestore = false
 
+const EmptyEdgeValue uint64 = 0
+
 // Configuration object for datastores
 type Options struct {
 	// The size of the in-memory cache. A value of 0 or lower disables the cache.

--- a/net/client.go
+++ b/net/client.go
@@ -18,6 +18,7 @@ import (
 	core "github.com/textileio/go-threads/core/net"
 	"github.com/textileio/go-threads/core/thread"
 	sym "github.com/textileio/go-threads/crypto/symmetric"
+	"github.com/textileio/go-threads/logstore/lstoreds"
 	pb "github.com/textileio/go-threads/net/pb"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -349,11 +350,8 @@ func (s *server) exchangeEdges(ctx context.Context, pid peer.ID, tids []thread.I
 	// fill local edges
 	for _, tid := range tids {
 		switch addrsEdge, headsEdge, err := s.localEdges(tid); err {
-		case errNoAddrsEdge:
-			log.Warnf("cannot compute edges for %s: no addresses", tid)
-		case errNoHeadsEdge:
-			log.Debugf("cannot compute edges for %s: no heads", tid)
-		case nil:
+		// we have lstoreds.EmptyEdgeValue for headsEdge and addrsEdge if we get errors below
+		case errNoAddrsEdge, errNoHeadsEdge, nil:
 			body.Threads = append(body.Threads, &pb.ExchangeEdgesRequest_Body_ThreadEntry{
 				ThreadID:    &pb.ProtoThreadID{ID: tid},
 				HeadsEdge:   headsEdge,
@@ -398,26 +396,30 @@ func (s *server) exchangeEdges(ctx context.Context, pid peer.ID, tids []thread.I
 		return err
 	}
 
-	for i, e := range reply.GetEdges() {
-		tid := tids[i]
-		if !e.GetExists() {
-			// invariant: respondent itself must request missing thread info
-			continue
-		}
+	for _, e := range reply.GetEdges() {
+		tid := e.ThreadID.ID
 
 		// get local edges potentially updated by another process
 		addrsEdgeLocal, headsEdgeLocal, err := s.localEdges(tid)
-		if err != nil {
+		// we allow local edges to be empty, because the other peer can still have more information
+		if err != nil && err != errNoHeadsEdge && err != errNoAddrsEdge {
 			log.Errorf("second retrieval of local edges for %s failed: %v", tid, err)
 			continue
 		}
 
-		if e.GetAddressEdge() != addrsEdgeLocal {
+		responseEdge := e.GetAddressEdge()
+		// We only update the logs if we got non empty values and different hashes for addresses
+		// Note that previous versions also sent 0 (aka EmptyEdgeValue) values when the addresses
+		// were non-existent, so it shouldn't break backwards compatibility
+		if responseEdge != lstoreds.EmptyEdgeValue && responseEdge != addrsEdgeLocal {
 			if s.net.queueGetLogs.Schedule(pid, tid, callPriorityLow, s.net.updateLogsFromPeer) {
 				log.Debugf("log information update for thread %s from %s scheduled", tid, pid)
 			}
 		}
-		if e.GetHeadsEdge() != headsEdgeLocal {
+
+		responseEdge = e.GetHeadsEdge()
+		// We only update the records if we got non empty values and different hashes for heads
+		if responseEdge != lstoreds.EmptyEdgeValue && responseEdge != headsEdgeLocal {
 			if s.net.queueGetRecords.Schedule(pid, tid, callPriorityLow, s.net.updateRecordsFromPeer) {
 				log.Debugf("record update for thread %s from %s scheduled", tid, pid)
 			}

--- a/net/pb/net.pb.go
+++ b/net/pb/net.pb.go
@@ -987,7 +987,7 @@ func (m *ExchangeEdgesReply) GetEdges() []*ExchangeEdgesReply_ThreadEdges {
 type ExchangeEdgesReply_ThreadEdges struct {
 	// threadID is the requested thread's ID.
 	ThreadID *ProtoThreadID `protobuf:"bytes,1,opt,name=threadID,proto3,customtype=ProtoThreadID" json:"threadID,omitempty"`
-	// exists is the flag indicating whether the requested thread exists on a respondent.
+	// deprecated, use default values for addressEdge and headsEdge
 	Exists bool `protobuf:"varint,2,opt,name=exists,proto3" json:"exists,omitempty"`
 	// addressEdge is the current hash of peers addresses stored on a respondent.
 	AddressEdge uint64 `protobuf:"varint,3,opt,name=addressEdge,proto3" json:"addressEdge,omitempty"`

--- a/net/pb/net.proto
+++ b/net/pb/net.proto
@@ -166,7 +166,7 @@ message ExchangeEdgesReply {
     message ThreadEdges {
         // threadID is the requested thread's ID.
         bytes threadID = 1 [(gogoproto.customtype) = "ProtoThreadID"];
-        // exists is the flag indicating whether the requested thread exists on a respondent.
+        // deprecated, use default values for addressEdge and headsEdge
         bool exists = 2;
         // addressEdge is the current hash of peers addresses stored on a respondent.
         uint64 addressEdge = 3;

--- a/net/server.go
+++ b/net/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/textileio/go-threads/cbor"
 	lstore "github.com/textileio/go-threads/core/logstore"
 	"github.com/textileio/go-threads/core/thread"
+	"github.com/textileio/go-threads/logstore/lstoreds"
 	pb "github.com/textileio/go-threads/net/pb"
 	"github.com/textileio/go-threads/util"
 	"google.golang.org/grpc"
@@ -301,58 +302,53 @@ func (s *server) ExchangeEdges(ctx context.Context, req *pb.ExchangeEdgesRequest
 	for _, entry := range req.Body.Threads {
 		var tid = entry.ThreadID.ID
 		switch addrsEdgeLocal, headsEdgeLocal, err := s.localEdges(tid); err {
-		case nil:
+		case errNoAddrsEdge, errNoHeadsEdge, nil:
 			var (
 				addrsEdgeRemote = entry.AddressEdge
 				headsEdgeRemote = entry.HeadsEdge
 			)
 
-			if addrsEdgeLocal != addrsEdgeRemote {
-				if s.net.queueGetLogs.Schedule(pid, tid, callPriorityLow, s.net.updateLogsFromPeer) {
+			// need to get new logs only if we have non empty addresses on remote and the hashes are different
+			if addrsEdgeRemote != lstoreds.EmptyEdgeValue && addrsEdgeLocal != addrsEdgeRemote {
+				prt := callPriorityLow
+				updateLogs := s.net.updateLogsFromPeer
+				// if we don't have the thread locally
+				if addrsEdgeLocal == lstoreds.EmptyEdgeValue {
+					prt = callPriorityHigh // we have to add thread in pubsub, not just update its logs
+					updateLogs = func(ctx context.Context, p peer.ID, t thread.ID) error {
+						if err := s.net.updateLogsFromPeer(ctx, p, t); err != nil {
+							return err
+						}
+						if s.net.server.ps != nil {
+							return s.net.server.ps.Add(t)
+						}
+						return nil
+					}
+				}
+				if s.net.queueGetLogs.Schedule(pid, tid, prt, updateLogs) {
 					log.Debugf("log information update for thread %s from %s scheduled", tid, pid)
 				}
 			}
-			if headsEdgeLocal != headsEdgeRemote {
+
+			// need to get new records only if we have non empty heads on remote and the hashes are different
+			if headsEdgeRemote != lstoreds.EmptyEdgeValue && headsEdgeLocal != headsEdgeRemote {
 				if s.net.queueGetRecords.Schedule(pid, tid, callPriorityLow, s.net.updateRecordsFromPeer) {
 					log.Debugf("record update for thread %s from %s scheduled", tid, pid)
 				}
 			}
 
+			// setting "exists" for backwards compatibility with older versions
+			// to get exactly same behaviour as was before
+			exists := true
+			if addrsEdgeLocal == lstoreds.EmptyEdgeValue || headsEdgeLocal == lstoreds.EmptyEdgeValue {
+				exists = false
+			}
+
 			reply.Edges = append(reply.Edges, &pb.ExchangeEdgesReply_ThreadEdges{
 				ThreadID:    &pb.ProtoThreadID{ID: tid},
-				Exists:      true,
+				Exists:      exists,
 				AddressEdge: addrsEdgeLocal,
 				HeadsEdge:   headsEdgeLocal,
-			})
-
-		case errNoAddrsEdge:
-			// requested thread doesn't exist locally
-			log.Warnf("addresses for requested thread %s not found", tid)
-			s.net.queueGetLogs.Schedule(
-				pid,
-				tid,
-				callPriorityHigh, // we have to add thread in pubsub, not just update its logs
-				func(ctx context.Context, p peer.ID, t thread.ID) error {
-					if err := s.net.updateLogsFromPeer(ctx, p, t); err != nil {
-						return err
-					}
-					if s.net.server.ps != nil {
-						return s.net.server.ps.Add(t)
-					}
-					return nil
-				})
-			reply.Edges = append(reply.Edges, &pb.ExchangeEdgesReply_ThreadEdges{
-				ThreadID: &pb.ProtoThreadID{ID: tid},
-				Exists:   false,
-			})
-
-		case errNoHeadsEdge:
-			// thread exists locally and contains addresses, but not heads - pull records for update
-			log.Debugf("heads for requested thread %s not found", tid)
-			s.net.queueGetRecords.Schedule(pid, tid, callPriorityLow, s.net.updateRecordsFromPeer)
-			reply.Edges = append(reply.Edges, &pb.ExchangeEdgesReply_ThreadEdges{
-				ThreadID: &pb.ProtoThreadID{ID: tid},
-				Exists:   false,
 			})
 
 		default:
@@ -401,6 +397,7 @@ func (s *server) headsChanged(req *pb.GetRecordsRequest) (bool, error) {
 
 // localEdges returns values of local addresses/heads edges for the thread.
 func (s *server) localEdges(tid thread.ID) (addrsEdge, headsEdge uint64, err error) {
+	headsEdge = lstoreds.EmptyEdgeValue
 	addrsEdge, err = s.net.store.AddrsEdge(tid)
 	if err != nil {
 		if errors.Is(err, lstore.ErrThreadNotFound) {


### PR DESCRIPTION
In Anytype we discovered that current synchronisation mechanism of `exchangeEdges` doesn’t provide for cases when we have threads empty logs (i.e. their heads are empty). For example in these cases we exclude such thread from exchange process and thus prevent other node to discover new logs. 

To remedy that I created the same PR as we have in our fork. The idea is that we still exchange information about such threads and send default values for respective hashes. We also made things backward compatible (because essentially previously we also sent empty values as hashes when we responded to `exchangeEdges` request, because 0s are used by default).
