### PR TITLE
Control thread pulling

### DIFF
--- a/api/service.go
+++ b/api/service.go
@@ -41,14 +41,10 @@ type Config struct {
 // NewService starts and returns a new service with the given network.
 // The network is *not* managed by the server.
 func NewService(store kt.TxnDatastoreExtended, network app.Net, conf Config) (*Service, error) {
-	var err error
-	if conf.Debug {
-		err = util.SetLogLevels(map[string]logging.LogLevel{
-			"threadsapi": logging.LevelDebug,
-		})
-		if err != nil {
-			return nil, err
-		}
+	if err := util.SetLogLevels(map[string]logging.LogLevel{
+		"threadsapi": util.LevelFromDebugFlag(conf.Debug),
+	}); err != nil {
+		return nil, err
 	}
 
 	manager, err := db.NewManager(store, network, db.WithNewDebug(conf.Debug))

--- a/db/db.go
+++ b/db/db.go
@@ -104,12 +104,10 @@ func NewDB(
 	for _, opt := range opts {
 		opt(args)
 	}
-	if args.Debug {
-		if err := util.SetLogLevels(map[string]logging.LogLevel{
-			"db": logging.LevelDebug,
-		}); err != nil {
-			return nil, err
-		}
+	if err := util.SetLogLevels(map[string]logging.LogLevel{
+		"db": util.LevelFromDebugFlag(args.Debug),
+	}); err != nil {
+		return nil, err
 	}
 
 	if args.Key.Defined() && !args.Key.CanRead() {
@@ -142,12 +140,10 @@ func NewDBFromAddr(
 	for _, opt := range opts {
 		opt(args)
 	}
-	if args.Debug {
-		if err := util.SetLogLevels(map[string]logging.LogLevel{
-			"db": logging.LevelDebug,
-		}); err != nil {
-			return nil, err
-		}
+	if err := util.SetLogLevels(map[string]logging.LogLevel{
+		"db": util.LevelFromDebugFlag(args.Debug),
+	}); err != nil {
+		return nil, err
 	}
 
 	if key.Defined() && !key.CanRead() {

--- a/db/manager.go
+++ b/db/manager.go
@@ -51,13 +51,10 @@ func NewManager(store kt.TxnDatastoreExtended, network app.Net, opts ...NewOptio
 	for _, opt := range opts {
 		opt(args)
 	}
-
-	if args.Debug {
-		if err := util.SetLogLevels(map[string]logging.LogLevel{
-			"db": logging.LevelDebug,
-		}); err != nil {
-			return nil, err
-		}
+	if err := util.SetLogLevels(map[string]logging.LogLevel{
+		"db": util.LevelFromDebugFlag(args.Debug),
+	}); err != nil {
+		return nil, err
 	}
 
 	m := &Manager{

--- a/integrationtests/foldersync/client.go
+++ b/integrationtests/foldersync/client.go
@@ -306,7 +306,7 @@ func (c *client) ensureCID(fullPath, cidStr string) error {
 		return err
 	}
 
-	log.Infof("Fetching file %s", fullPath)
+	log.Infof("fetching file %s", fullPath)
 	d1 := time.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
@@ -328,7 +328,7 @@ func (c *client) ensureCID(fullPath, cidStr string) error {
 	}
 	d2 := time.Now()
 	d := d2.Sub(d1)
-	log.Infof("Done fetching %s in %dms", fullPath, d.Milliseconds())
+	log.Infof("done fetching %s in %dms", fullPath, d.Milliseconds())
 	return nil
 }
 

--- a/net/api/service.go
+++ b/net/api/service.go
@@ -39,14 +39,10 @@ type Config struct {
 
 // NewService starts and returns a new service.
 func NewService(network net.Net, conf Config) (*Service, error) {
-	var err error
-	if conf.Debug {
-		err = tutil.SetLogLevels(map[string]logging.LogLevel{
-			"netapi": logging.LevelDebug,
-		})
-		if err != nil {
-			return nil, err
-		}
+	if err := tutil.SetLogLevels(map[string]logging.LogLevel{
+		"netapi": tutil.LevelFromDebugFlag(conf.Debug),
+	}); err != nil {
+		return nil, err
 	}
 	return &Service{net: network}, nil
 }

--- a/net/client.go
+++ b/net/client.go
@@ -109,7 +109,7 @@ func (s *server) getRecords(
 	peers []peer.ID,
 	tid thread.ID,
 	offsets map[peer.ID]thread.Head,
-	limit int,
+	limit uint,
 ) (map[peer.ID]peerRecords, error) {
 	req, sk, err := s.buildGetRecordsRequest(tid, offsets, limit)
 	if err != nil {
@@ -151,7 +151,7 @@ func (s *server) getRecords(
 func (s *server) buildGetRecordsRequest(
 	tid thread.ID,
 	offsets map[peer.ID]thread.Head,
-	limit int,
+	limit uint,
 ) (req *pb.GetRecordsRequest, serviceKey *sym.Key, err error) {
 	serviceKey, err = s.net.store.ServiceKey(tid)
 	if err != nil {

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -445,8 +445,12 @@ func makeNetwork(t *testing.T) core.Net {
 		dag.NewDAGService(bsrv),
 		tstore.NewLogstore(),
 		Config{
-			Debug:  true,
-			PubSub: true,
+			PullThreadsLimit:           10000,
+			PullThreadsStartAfter:      time.Second,
+			PullThreadsInitialInterval: time.Second,
+			PullThreadsInterval:        time.Second * 10,
+			PubSub:                     true,
+			Debug:                      true,
 		}, nil, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 func TestNet_GetToken(t *testing.T) {
-	t.Parallel()
 	n := makeNetwork(t)
 	defer n.Close()
 	ctx := context.Background()
@@ -46,7 +45,6 @@ func TestNet_GetToken(t *testing.T) {
 }
 
 func TestNet_CreateRecord(t *testing.T) {
-	t.Parallel()
 	n := makeNetwork(t)
 	defer n.Close()
 	ctx := context.Background()
@@ -110,7 +108,6 @@ func TestNet_CreateRecord(t *testing.T) {
 }
 
 func TestNet_AddThread(t *testing.T) {
-	t.Parallel()
 	n1 := makeNetwork(t)
 	defer n1.Close()
 	n2 := makeNetwork(t)
@@ -175,7 +172,6 @@ func TestNet_AddThread(t *testing.T) {
 }
 
 func TestNet_CreateThreadManaged(t *testing.T) {
-	t.Parallel()
 	n := makeNetwork(t)
 	defer n.Close()
 
@@ -210,7 +206,6 @@ func TestNet_CreateThreadManaged(t *testing.T) {
 }
 
 func TestNet_AddThreadManaged(t *testing.T) {
-	t.Parallel()
 	n1 := makeNetwork(t)
 	defer n1.Close()
 	n2 := makeNetwork(t)
@@ -268,7 +263,6 @@ func TestNet_AddThreadManaged(t *testing.T) {
 }
 
 func TestNet_AddReplicator(t *testing.T) {
-	t.Parallel()
 	n1 := makeNetwork(t)
 	defer n1.Close()
 	n2 := makeNetwork(t)
@@ -322,7 +316,6 @@ func TestNet_AddReplicator(t *testing.T) {
 }
 
 func TestNet_AddReplicatorManaged(t *testing.T) {
-	t.Parallel()
 	n1 := makeNetwork(t)
 	defer n1.Close()
 	n2 := makeNetwork(t)
@@ -380,7 +373,6 @@ func TestNet_AddReplicatorManaged(t *testing.T) {
 }
 
 func TestNet_DeleteThread(t *testing.T) {
-	t.Parallel()
 	n := makeNetwork(t)
 	defer n.Close()
 
@@ -410,7 +402,6 @@ func TestNet_DeleteThread(t *testing.T) {
 }
 
 func TestClose(t *testing.T) {
-	t.Parallel()
 	n := makeNetwork(t)
 	defer n.Close()
 
@@ -449,7 +440,7 @@ func makeNetwork(t *testing.T) core.Net {
 			NetPullingStartAfter:      time.Second,
 			NetPullingInitialInterval: time.Second,
 			NetPullingInterval:        time.Second * 10,
-			PubSub:                    true,
+			PubSub:                    false,
 			Debug:                     true,
 		}, nil, nil)
 	if err != nil {

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -445,12 +445,12 @@ func makeNetwork(t *testing.T) core.Net {
 		dag.NewDAGService(bsrv),
 		tstore.NewLogstore(),
 		Config{
-			PullThreadsLimit:           10000,
-			PullThreadsStartAfter:      time.Second,
-			PullThreadsInitialInterval: time.Second,
-			PullThreadsInterval:        time.Second * 10,
-			PubSub:                     true,
-			Debug:                      true,
+			NetPullingLimit:           10000,
+			NetPullingStartAfter:      time.Second,
+			NetPullingInitialInterval: time.Second,
+			NetPullingInterval:        time.Second * 10,
+			PubSub:                    true,
+			Debug:                     true,
 		}, nil, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/net/server.go
+++ b/net/server.go
@@ -191,7 +191,7 @@ func (s *server) GetRecords(ctx context.Context, req *pb.GetRecordsRequest) (*pb
 	pbrecs.Logs = make([]*pb.GetRecordsReply_LogEntry, 0, len(info.Logs))
 
 	var (
-		logRecordLimit = s.net.conf.PullThreadsLimit / len(info.Logs)
+		logRecordLimit = int(s.net.conf.NetPullingLimit) / len(info.Logs)
 		mx             sync.Mutex
 		wg             sync.WaitGroup
 	)

--- a/net/server.go
+++ b/net/server.go
@@ -38,7 +38,7 @@ type server struct {
 }
 
 // newServer creates a new network server.
-func newServer(n *net, enablePubSub bool, opts ...grpc.DialOption) (*server, error) {
+func newServer(n *net, opts ...grpc.DialOption) (*server, error) {
 	var (
 		s = &server{
 			net:   n,
@@ -53,7 +53,7 @@ func newServer(n *net, enablePubSub bool, opts ...grpc.DialOption) (*server, err
 
 	s.opts = append(defaultOpts, opts...)
 
-	if enablePubSub {
+	if n.conf.PubSub {
 		ps, err := pubsub.NewGossipSub(
 			n.ctx,
 			n.host,
@@ -191,7 +191,7 @@ func (s *server) GetRecords(ctx context.Context, req *pb.GetRecordsRequest) (*pb
 	pbrecs.Logs = make([]*pb.GetRecordsReply_LogEntry, 0, len(info.Logs))
 
 	var (
-		logRecordLimit = MaxPullLimit / len(info.Logs)
+		logRecordLimit = s.net.conf.PullThreadsLimit / len(info.Logs)
 		mx             sync.Mutex
 		wg             sync.WaitGroup
 	)

--- a/threadsd/main.go
+++ b/threadsd/main.go
@@ -36,15 +36,15 @@ func main() {
 	hostAddrStr := fs.String("hostAddr", "/ip4/0.0.0.0/tcp/4006", "Libp2p host bind address")
 	apiAddrStr := fs.String("apiAddr", "/ip4/127.0.0.1/tcp/6006", "gRPC API bind address")
 	apiProxyAddrStr := fs.String("apiProxyAddr", "/ip4/127.0.0.1/tcp/6007", "gRPC API web proxy bind address")
-	connLowWater := fs.Int("connLowWater", 100, "Low watermark of libp2p connections that'll be maintained")
-	connHighWater := fs.Int("connHighWater", 400, "High watermark of libp2p connections that'll be maintained")
+	connLowWater := fs.Uint("connLowWater", 100, "Low watermark of libp2p connections that'll be maintained")
+	connHighWater := fs.Uint("connHighWater", 400, "High watermark of libp2p connections that'll be maintained")
 	connGracePeriod := fs.Duration("connGracePeriod", time.Second*20, "Duration a new opened connection is not subject to pruning")
 	keepAliveInterval := fs.Duration("keepAliveInterval", time.Second*5, "Websocket keepalive interval (must be >= 1s)")
-	pullThreadsDisabled := fs.Bool("pullThreadsDisabled", false, "Disables automatic thread record and log pulling from peers")
-	pullThreadsLimit := fs.Int("pullThreadsLimit", 10000, "Maximum number of records to request from peers during a single pull (must be > 0)")
-	pullThreadsStartAfter := fs.Duration("pullThreadsStartAfter", time.Second, "Delay after which thread pulling from peers starts (must be > 0)")
-	pullThreadsInitialInterval := fs.Duration("pullThreadsInitialInterval", time.Second, "Initial (first run) interval at threads are pulled from peers (must be > 0)")
-	pullThreadsInterval := fs.Duration("pullThreadsInterval", time.Second*10, "Interval at which threads are pulled from peers (must be > 0)")
+	disableNetPulling := fs.Bool("disableNetPulling", false, "Disables automatic thread record and log pulling from network peers")
+	netPullingLimit := fs.Uint("netPullingLimit", 10000, "Maximum number of records to request from network peers during a single pull (must be > 0)")
+	netPullingStartAfter := fs.Duration("netPullingStartAfter", time.Second, "Delay after which thread pulling from network peers starts (must be > 0)")
+	netPullingInitialInterval := fs.Duration("netPullingInitialInterval", time.Second, "Initial (first run) interval at which threads are pulled from network peers (must be > 0)")
+	netPullingInterval := fs.Duration("netPullingInterval", time.Second*10, "Interval at which threads are pulled from network peers (must be > 0)")
 	enableNetPubsub := fs.Bool("enableNetPubsub", false, "Enables thread networking over libp2p pubsub")
 	mongoUri := fs.String("mongoUri", "", "MongoDB URI (if not provided, an embedded Badger datastore will be used)")
 	mongoDatabase := fs.String("mongoDatabase", "", "MongoDB database name (required with mongoUri")
@@ -109,14 +109,14 @@ func main() {
 
 	opts := []common.NetOption{
 		common.WithNetHostAddr(hostAddr),
-		common.WithConnectionManager(connmgr.NewConnManager(*connLowWater, *connHighWater, *connGracePeriod)),
+		common.WithConnectionManager(connmgr.NewConnManager(int(*connLowWater), int(*connHighWater), *connGracePeriod)),
 		common.WithNetPulling(
-			*pullThreadsDisabled,
-			*pullThreadsLimit,
-			*pullThreadsStartAfter,
-			*pullThreadsInitialInterval,
-			*pullThreadsInterval,
+			*netPullingLimit,
+			*netPullingStartAfter,
+			*netPullingInitialInterval,
+			*netPullingInterval,
 		),
+		common.WithNoNetPulling(*disableNetPulling),
 		common.WithNetPubSub(*enableNetPubsub),
 		common.WithNetLogstore(common.LogstoreHybrid),
 		common.WithNetDebug(*debug),

--- a/util/util.go
+++ b/util/util.go
@@ -56,19 +56,19 @@ func NewBadgerDatastore(dirPath, name string, lowMem bool) (kt.TxnDatastoreExten
 }
 
 // SetupDefaultLoggingConfig sets up a standard logging configuration.
-func SetupDefaultLoggingConfig(repoPath string) error {
-	folder := filepath.Join(repoPath, "log")
-	if err := os.MkdirAll(folder, os.ModePerm); err != nil {
-		return err
-	}
+func SetupDefaultLoggingConfig(file string) error {
 	c := logging.Config{
 		Format: logging.ColorizedOutput,
 		Stderr: true,
-		File:   filepath.Join(folder, "threads.log"),
 		Level:  logging.LevelError,
 	}
+	if file != "" {
+		if err := os.MkdirAll(file, os.ModePerm); err != nil {
+			return err
+		}
+		c.File = file
+	}
 	logging.SetupLogging(c)
-
 	return nil
 }
 
@@ -88,6 +88,15 @@ func SetLogLevels(systems map[string]logging.LogLevel) error {
 		}
 	}
 	return nil
+}
+
+// LevelFromDebugFlag returns the debug or info log level.
+func LevelFromDebugFlag(debug bool) logging.LogLevel {
+	if debug {
+		return logging.LevelDebug
+	} else {
+		return logging.LevelInfo
+	}
 }
 
 func DefaultBoostrapPeers() []peer.AddrInfo {

--- a/util/util.go
+++ b/util/util.go
@@ -63,7 +63,7 @@ func SetupDefaultLoggingConfig(file string) error {
 		Level:  logging.LevelError,
 	}
 	if file != "" {
-		if err := os.MkdirAll(file, os.ModePerm); err != nil {
+		if err := os.MkdirAll(filepath.Dir(file), os.ModePerm); err != nil {
 			return err
 		}
 		c.File = file


### PR DESCRIPTION
- Moves thread pulling control to config vars and flags.
- Makes logging level `INFO` by default instead of just `ERROR`.