### PR TITLE
Use go1.17.5 for docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM golang:1.15.5-buster
-MAINTAINER Textile <contact@textile.io>
+FROM golang:1.17.5-buster
+LABEL maintainer="Textile <contact@textile.io>"
 
 # This is (in large part) copied (with love) from
 # https://hub.docker.com/r/ipfs/go-ipfs/dockerfile


### PR DESCRIPTION
This PR updates the go version used for building the project in the docker image.
Some advantages include performance benefits and less likely to contain security issues. 