### PR TITLE
Fix panic in ensureUniqueLog - GetFirstPrivKeyLog() can return null s…

### DIFF
--- a/net/net.go
+++ b/net/net.go
@@ -1575,7 +1575,8 @@ func (n *net) ensureUniqueLog(id thread.ID, key crypto.Key, identity thread.PubK
 		if lidb == nil {
 			// Check if we have an old-style "own" (unindexed) log
 			if identity.Equals(thread.NewLibp2pPubKey(n.getPrivKey().GetPublic())) {
-				if thrd.GetFirstPrivKeyLog().PrivKey != nil {
+				li := thrd.GetFirstPrivKeyLog()
+				if li != nil && li.PrivKey != nil {
 					return lstore.ErrThreadExists
 				}
 			}


### PR DESCRIPTION
…o the test for PrivKey afterwards can panic

Signed-off-by: vkost <viktor.kostadinov@gmail.com>